### PR TITLE
Add a servlet to retrieve user information from the datastore based on authentication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,26 +59,28 @@
 
     <dependency>
       <groupId>com.google.appengine</groupId>
-      <artifactId>appengine-api-1.0-sdk</artifactId>
-      <version>1.9.59</version>
-    </dependency>
-
-    <!-- https://mvnrepository.com/artifact/com.google.appengine/appengine-testing -->
-    <!-- Provides helper classes to simulate UserService and Datastore states -->
-    <dependency>
-      <groupId>com.google.appengine</groupId>
       <artifactId>appengine-testing</artifactId>
-      <version>1.9.80</version>
+      <version>1.9.59</version>
       <scope>test</scope>
     </dependency>
 
-    <!-- https://mvnrepository.com/artifact/com.google.appengine/appengine-api-stubs -->
-    <!-- appengine-testing depends on this -->
     <dependency>
       <groupId>com.google.appengine</groupId>
       <artifactId>appengine-api-stubs</artifactId>
-      <version>1.9.80</version>
+      <version>1.9.59</version>
       <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-labs</artifactId>
+      <version>1.9.59</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-tools-sdk</artifactId>
+      <version>1.9.59</version>
     </dependency>
 
     <!--    This is a wrapper for The Movie DB API. Here is the github: https://github.com/holgerbrandl/themoviedbapi-->

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/com.google.appengine/appengine-testing -->
+    <!-- Provides helper classes to simulate UserService and Datastore states -->
     <dependency>
       <groupId>com.google.appengine</groupId>
       <artifactId>appengine-testing</artifactId>
@@ -72,6 +73,7 @@
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/com.google.appengine/appengine-api-stubs -->
+    <!-- appengine-testing depends on this -->
     <dependency>
       <groupId>com.google.appengine</groupId>
       <artifactId>appengine-api-stubs</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,24 @@
       <artifactId>appengine-api-1.0-sdk</artifactId>
       <version>1.9.59</version>
     </dependency>
-<!--    This is a wrapper for The Movie DB API. Here is the github: https://github.com/holgerbrandl/themoviedbapi-->
+
+    <!-- https://mvnrepository.com/artifact/com.google.appengine/appengine-testing -->
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-testing</artifactId>
+      <version>1.9.80</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- https://mvnrepository.com/artifact/com.google.appengine/appengine-api-stubs -->
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-stubs</artifactId>
+      <version>1.9.80</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!--    This is a wrapper for The Movie DB API. Here is the github: https://github.com/holgerbrandl/themoviedbapi-->
 <!--    Here is the API Docs: https://developers.themoviedb.org/-->
     <dependency>
       <groupId>info.movito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,12 @@
 
     <dependency>
       <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-1.0-sdk</artifactId>
+      <version>1.9.59</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.appengine</groupId>
       <artifactId>appengine-testing</artifactId>
       <version>1.9.59</version>
       <scope>test</scope>
@@ -75,6 +81,7 @@
       <groupId>com.google.appengine</groupId>
       <artifactId>appengine-api-labs</artifactId>
       <version>1.9.59</version>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/src/main/java/com/google/sps/ContextListener.java
+++ b/src/main/java/com/google/sps/ContextListener.java
@@ -4,6 +4,7 @@ package com.google.sps;
 import com.google.sps.model.queue.EntityDbQueue;
 import com.google.sps.model.queue.WantToWatchQueueObject;
 import com.google.sps.model.queue.WatchedQueueObject;
+import com.google.sps.servlets.user.UserObject;
 import com.googlecode.objectify.ObjectifyService;
 
 import javax.servlet.ServletContextEvent;
@@ -32,5 +33,6 @@ public class ContextListener implements ServletContextListener {
         ObjectifyService.register(EntityDbQueue.class);
         ObjectifyService.register(WantToWatchQueueObject.class);
         ObjectifyService.register(WatchedQueueObject.class);
+        ObjectifyService.register(UserObject.class);
     }
 }

--- a/src/main/java/com/google/sps/servlets/user/UserObject.java
+++ b/src/main/java/com/google/sps/servlets/user/UserObject.java
@@ -1,0 +1,71 @@
+package com.google.sps.servlets.user;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.googlecode.objectify.annotation.Entity;
+import com.googlecode.objectify.annotation.Id;
+import com.googlecode.objectify.annotation.Index;
+
+import javax.jws.soap.SOAPBinding;
+
+@Entity(name="User")
+public class UserObject {
+
+    @Id
+    @Index
+    @JsonProperty
+    private String id;
+
+    @JsonProperty
+    @Index
+    private String username;
+
+    @JsonProperty
+    @Index
+    private String email;
+
+    @JsonProperty
+    @Index
+    private String profilePicUrl;
+
+    public UserObject() {} // For Objectify
+
+    public UserObject(String id, String username, String email, String profilePicUrl) {
+        this.id = id;
+        this.username = username;
+        this.email = email;
+        this.profilePicUrl = profilePicUrl;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getProfilePicUrl() {
+        return profilePicUrl;
+    }
+
+    public void setProfilePicUrl(String profilePicUrl) {
+        this.profilePicUrl = profilePicUrl;
+    }
+}
+

--- a/src/main/java/com/google/sps/servlets/user/UserObject.java
+++ b/src/main/java/com/google/sps/servlets/user/UserObject.java
@@ -5,8 +5,6 @@ import com.googlecode.objectify.annotation.Entity;
 import com.googlecode.objectify.annotation.Id;
 import com.googlecode.objectify.annotation.Index;
 
-import javax.jws.soap.SOAPBinding;
-
 @Entity(name="User")
 public class UserObject {
 

--- a/src/main/java/com/google/sps/servlets/user/UserServlet.java
+++ b/src/main/java/com/google/sps/servlets/user/UserServlet.java
@@ -68,7 +68,7 @@ public class UserServlet extends HttpServlet {
     /**
      * doGet() returns details of the particular user with the given id
      * Returns error 400 if no id is provided
-     * Returns error 500 if the user cannot be found
+     * Returns error 404 if the user cannot be found
      * @param request: expects id parameter
      * @param response: returns a Volume object
      * @throws IOException
@@ -88,7 +88,7 @@ public class UserServlet extends HttpServlet {
 
         UserEntity userEntity = getStoredUser(id);
         if (userEntity == null) {
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+            response.sendError(HttpServletResponse.SC_NOT_FOUND);
             return;
         }
 

--- a/src/main/java/com/google/sps/servlets/user/UserServlet.java
+++ b/src/main/java/com/google/sps/servlets/user/UserServlet.java
@@ -1,0 +1,101 @@
+package com.google.sps.servlets.user;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
+import com.google.appengine.api.users.User;
+import com.google.gson.Gson;
+
+/** Servlet that returns user information.
+ *  Returns additional information if the query is for the current user
+ */
+@WebServlet("/user")
+public class UserServlet extends HttpServlet {
+
+    Gson gson = new Gson();
+
+    public static class UserEntity {
+        String id;
+        String username;
+        String email;
+        String profilePicUrl;
+
+        public UserEntity(String id, String username, String email, String profilePicUrl) {
+            this.id = id;
+            this.username = username;
+            this.email = email;
+            this.profilePicUrl = profilePicUrl;
+        }
+    }
+
+    // Search Datastore for an entry for the user
+    public static Entity checkDatastore(String id) {
+        DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+        Query query = new Query("User")
+                .setFilter(new Query.FilterPredicate("id", Query.FilterOperator.EQUAL, id));
+        PreparedQuery results = datastore.prepare(query);
+        try {
+            return results.asSingleEntity();
+        }
+        catch (Exception e) {
+            return null;
+        }
+    }
+
+    private UserEntity getStoredUser(String id) {
+        Entity entity = checkDatastore(id);
+        if (entity == null) return null;
+
+        return new UserEntity(
+            (String) entity.getProperty("id"),
+            (String) entity.getProperty("username"),
+            (String) entity.getProperty("email"),
+            (String) entity.getProperty("profilePicUrl")
+        );
+    }
+
+    /**
+     * doGet() returns details of the particular user with the given id
+     * Returns error 400 if no id is provided
+     * Returns error 500 if the user cannot be found
+     * @param request: expects id parameter
+     * @param response: returns a Volume object
+     * @throws IOException
+     */
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        response.setContentType("application/json; charset=utf-8");
+
+        UserService userService = UserServiceFactory.getUserService();
+        User user = userService.getCurrentUser();
+
+        String id = request.getParameter("id");
+        if (id == null || id.equals("")) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        UserEntity userEntity = getStoredUser(id);
+        if (userEntity == null) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        if (user == null || !user.getUserId().equals(id)) {
+            userEntity.email = "";
+        }
+
+        response.getWriter().println(gson.toJson(userEntity));
+    }
+}

--- a/src/test/java/com/google/sps/servlets/user/UserServletTest.java
+++ b/src/test/java/com/google/sps/servlets/user/UserServletTest.java
@@ -1,16 +1,12 @@
 package com.google.sps.servlets.user;
 
-import org.junit.Before;
 import org.junit.After;
 import org.junit.Test;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
-import com.google.appengine.api.datastore.PreparedQuery;
-import com.google.appengine.api.datastore.Query;
 
 import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
@@ -23,9 +19,6 @@ import java.io.StringWriter;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.google.appengine.api.users.UserService;
-import com.google.appengine.api.users.UserServiceFactory;
-import com.google.appengine.api.users.User;
 import com.google.gson.Gson;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/google/sps/servlets/user/UserServletTest.java
+++ b/src/test/java/com/google/sps/servlets/user/UserServletTest.java
@@ -1,12 +1,14 @@
 package com.google.sps.servlets.user;
 
+import com.google.sps.ContextListener;
 import org.junit.After;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 import org.mockito.Mockito;
 
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
-import com.google.appengine.api.datastore.Entity;
 
 import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
@@ -21,7 +23,7 @@ import java.util.Map;
 
 import com.google.gson.Gson;
 
-import static org.junit.Assert.assertEquals;
+import static com.googlecode.objectify.ObjectifyService.ofy;
 
 public class UserServletTest extends Mockito {
 
@@ -29,9 +31,15 @@ public class UserServletTest extends Mockito {
             new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
     Gson gson = new Gson();
 
+    @BeforeClass
+    public static void initialize() {
+        new ContextListener().initDbObjects();
+    }
+
     @After
     public void tearDown() {
         helper.tearDown();
+        ofy().clear();
     }
 
     /**
@@ -128,13 +136,8 @@ public class UserServletTest extends Mockito {
 
         HttpServletResponse response = mock(HttpServletResponse.class);
 
-        DatastoreService ds = DatastoreServiceFactory.getDatastoreService();
-        Entity entity = new Entity("User");
-        entity.setProperty("id", "123");
-        entity.setProperty("username", "test");
-        entity.setProperty("email", "test@example.com");
-        entity.setProperty("profilePicUrl", "");
-        ds.put(entity);
+        UserObject user = new UserObject("123", "test", "test@example.com", "");
+        ofy().save().entity(user).now();
 
         StringWriter stringWriter = new StringWriter();
         PrintWriter writer = new PrintWriter(stringWriter);
@@ -145,7 +148,7 @@ public class UserServletTest extends Mockito {
         verify(request, atLeast(1)).getParameter("id");
         writer.flush();
 
-        String expected = gson.toJson(new UserServlet.UserEntity("123", "test", "", ""));
+        String expected = gson.toJson(user);
         assertEquals(stringWriter.toString().trim(), expected.trim());
     }
 
@@ -170,13 +173,10 @@ public class UserServletTest extends Mockito {
 
         HttpServletResponse response = mock(HttpServletResponse.class);
 
-        DatastoreService ds = DatastoreServiceFactory.getDatastoreService();
-        Entity entity = new Entity("User");
-        entity.setProperty("id", "123");
-        entity.setProperty("username", "test");
-        entity.setProperty("email", "test@example.com");
-        entity.setProperty("profilePicUrl", "");
-        ds.put(entity);
+        UserObject user = new UserObject("123", "test", "test@example.com", "");
+        ofy().save().entity(user).now();
+
+        UserObject expectedUser = new UserObject("123", "test", "", "");
 
         StringWriter stringWriter = new StringWriter();
         PrintWriter writer = new PrintWriter(stringWriter);
@@ -187,7 +187,7 @@ public class UserServletTest extends Mockito {
         verify(request, atLeast(1)).getParameter("id");
         writer.flush();
 
-        String expected = gson.toJson(new UserServlet.UserEntity("123", "test", "", ""));
+        String expected = gson.toJson(expectedUser);
         assertEquals(stringWriter.toString().trim(), expected.trim());
     }
 
@@ -212,13 +212,8 @@ public class UserServletTest extends Mockito {
 
         HttpServletResponse response = mock(HttpServletResponse.class);
 
-        DatastoreService ds = DatastoreServiceFactory.getDatastoreService();
-        Entity entity = new Entity("User");
-        entity.setProperty("id", "123");
-        entity.setProperty("username", "test");
-        entity.setProperty("email", "test@example.com");
-        entity.setProperty("profilePicUrl", "");
-        ds.put(entity);
+        UserObject user = new UserObject("123", "test", "test@example.com", "");
+        ofy().save().entity(user).now();
 
         StringWriter stringWriter = new StringWriter();
         PrintWriter writer = new PrintWriter(stringWriter);
@@ -229,7 +224,7 @@ public class UserServletTest extends Mockito {
         verify(request, atLeast(1)).getParameter("id");
         writer.flush();
 
-        String expected = gson.toJson(new UserServlet.UserEntity("123", "test", "test@example.com", ""));
+        String expected = gson.toJson(user);
         assertEquals(stringWriter.toString().trim(), expected.trim());
     }
 }

--- a/src/test/java/com/google/sps/servlets/user/UserServletTest.java
+++ b/src/test/java/com/google/sps/servlets/user/UserServletTest.java
@@ -35,6 +35,56 @@ public class UserServletTest extends Mockito {
     }
 
     /**
+     * Ensure error is thrown when no id is provided
+     * @throws IOException
+     */
+    @Test
+    public void testMissingId() throws IOException {
+        helper.setEnvIsLoggedIn(false)
+                .setUp();
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        StringWriter stringWriter = new StringWriter();
+        PrintWriter writer = new PrintWriter(stringWriter);
+        writer.flush();
+        when(response.getWriter()).thenReturn(writer);
+
+        new UserServlet().doGet(request, response);
+        verify(request, atLeast(1)).getParameter("id");
+        writer.flush();
+
+        verify(response, times(1)).sendError(HttpServletResponse.SC_BAD_REQUEST);
+    }
+
+    /**
+     * Ensure error is thrown when the id field is equal to ""
+     * @throws IOException
+     */
+    @Test
+    public void testEmptyId() throws IOException {
+        helper.setEnvIsLoggedIn(false)
+                .setUp();
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getParameter("id")).thenReturn("");
+
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        StringWriter stringWriter = new StringWriter();
+        PrintWriter writer = new PrintWriter(stringWriter);
+        writer.flush();
+        when(response.getWriter()).thenReturn(writer);
+
+        new UserServlet().doGet(request, response);
+        verify(request, atLeast(1)).getParameter("id");
+        writer.flush();
+
+        verify(response, times(1)).sendError(HttpServletResponse.SC_BAD_REQUEST);
+    }
+
+    /**
      * Retrieve a non-existing user from the Datastore
      * @throws IOException
      */

--- a/src/test/java/com/google/sps/servlets/user/UserServletTest.java
+++ b/src/test/java/com/google/sps/servlets/user/UserServletTest.java
@@ -109,7 +109,7 @@ public class UserServletTest extends Mockito {
         verify(request, atLeast(1)).getParameter("id");
         writer.flush();
 
-        verify(response, times(1)).sendError(HttpServletResponse.SC_BAD_REQUEST);
+        verify(response, times(1)).sendError(HttpServletResponse.SC_NOT_FOUND);
     }
 
     /**

--- a/src/test/java/com/google/sps/servlets/user/UserServletTest.java
+++ b/src/test/java/com/google/sps/servlets/user/UserServletTest.java
@@ -1,0 +1,127 @@
+package com.google.sps.servlets.user;
+
+import org.junit.Before;
+import org.junit.After;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
+import com.google.appengine.api.users.User;
+import com.google.gson.Gson;
+
+import static org.junit.Assert.assertEquals;
+
+public class UserServletTest extends Mockito {
+
+    private final LocalServiceTestHelper helper =
+            new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
+    Gson gson = new Gson();
+
+    @After
+    public void tearDown() {
+        helper.tearDown();
+    }
+
+    /**
+     * Retrieve an existing user from the Datastore
+     * Accessed by an authenticated user different from the search target
+     * Should hide the user's email address
+     * @throws IOException
+     */
+    @Test
+    public void testStoredUserFromOther() throws IOException {
+        Map<String, Object> attr = new HashMap<>();
+        attr.put("com.google.appengine.api.users.UserService.user_id_key", "777");
+        helper.setEnvEmail("other@example.com")
+                .setEnvAttributes(attr)
+                .setEnvAuthDomain("example.com")
+                .setEnvIsLoggedIn(true)
+                .setUp();
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getParameter("id")).thenReturn("123");
+
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        DatastoreService ds = DatastoreServiceFactory.getDatastoreService();
+        Entity entity = new Entity("User");
+        entity.setProperty("id", "123");
+        entity.setProperty("username", "test");
+        entity.setProperty("email", "test@example.com");
+        entity.setProperty("profilePicUrl", "");
+        ds.put(entity);
+
+        StringWriter stringWriter = new StringWriter();
+        PrintWriter writer = new PrintWriter(stringWriter);
+        writer.flush();
+        when(response.getWriter()).thenReturn(writer);
+
+        new UserServlet().doGet(request, response);
+        verify(request, atLeast(1)).getParameter("id");
+        writer.flush();
+
+        String expected = gson.toJson(new UserServlet.UserEntity("123", "test", "", ""));
+        assertEquals(stringWriter.toString().trim(), expected.trim());
+    }
+
+    /**
+     * Retrieve an existing user from the Datastore
+     * Instance where the user searches for themselves
+     * Response should include their email address
+     * @throws IOException
+     */
+    @Test
+    public void testStoredUserFromSelf() throws IOException {
+        Map<String, Object> attr = new HashMap<>();
+        attr.put("com.google.appengine.api.users.UserService.user_id_key", "123");
+        helper.setEnvEmail("test@example.com")
+                .setEnvAttributes(attr)
+                .setEnvAuthDomain("example.com")
+                .setEnvIsLoggedIn(true)
+                .setUp();
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getParameter("id")).thenReturn("123");
+
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        DatastoreService ds = DatastoreServiceFactory.getDatastoreService();
+        Entity entity = new Entity("User");
+        entity.setProperty("id", "123");
+        entity.setProperty("username", "test");
+        entity.setProperty("email", "test@example.com");
+        entity.setProperty("profilePicUrl", "");
+        ds.put(entity);
+
+        StringWriter stringWriter = new StringWriter();
+        PrintWriter writer = new PrintWriter(stringWriter);
+        writer.flush();
+        when(response.getWriter()).thenReturn(writer);
+
+        new UserServlet().doGet(request, response);
+        verify(request, atLeast(1)).getParameter("id");
+        writer.flush();
+
+        String expected = gson.toJson(new UserServlet.UserEntity("123", "test", "test@example.com", ""));
+        assertEquals(stringWriter.toString().trim(), expected.trim());
+    }
+}


### PR DESCRIPTION
UserServlet defines the API endpoint /user, accepting a GET request with a required `id` parameter. The request throws an error if the `id` parameter is missing or empty, or if no matching user is found in the Datastore. The returned email field is equal to "" unless the requester is both authenticated and has a matching `id` to the query (i.e. users can only see their own emails).

UserServletTest provides several tests of this servlet. Leveraging the appengine-testing library (added to `pom.xml`, along with a co-dependency), it emulates various states of the Datastore and UserService. The tests ensure:

1. That query for a nonexistent user fails properly
2. That unauthenticated or other-user access to an existing user returns all information except for the email
3. That a user querying their own `id` returns all information, including email
4. That empty and missing `id` query parameters cause a proper error