### PR TITLE
Fix for *.xml files disappearing during Angular builds

### DIFF
--- a/mediaphile/angular.json
+++ b/mediaphile/angular.json
@@ -17,6 +17,7 @@
         "build": {
           "builder": "@angular-devkit/build-angular:browser",
           "options": {
+            "deleteOutputPath": false,
             "outputPath": "../src/main/webapp/",
             "index": "src/index.html",
             "main": "src/main.ts",


### PR DESCRIPTION
## Majors
 - Fix for *.xml files disappearing during Angular builds.
 - Allows for routing files to stay in place. 