### PR TITLE
Add a profile page for the Angular frontend

### DIFF
--- a/mediaphile/src/app/app-routing.module.ts
+++ b/mediaphile/src/app/app-routing.module.ts
@@ -8,7 +8,7 @@ import {LoginComponent} from "./pages/login/login.component";
 import {HomeComponent} from "./pages/home/home.component";
 import {AuthGuardService} from "./auth/auth-guard.service";
 import {QueueComponent} from "./pages/home/queue/queue.component";
-
+import {UserProfileComponent} from "./pages/user-profile/user-profile.component";
 
 const routes: Routes = [
   {
@@ -44,6 +44,10 @@ const routes: Routes = [
   {
     path:"queue",
     component: QueueComponent
+  },
+  {
+    path: "user/:id",
+    component: UserProfileComponent
   }
 ];
 

--- a/mediaphile/src/app/app.module.ts
+++ b/mediaphile/src/app/app.module.ts
@@ -26,6 +26,7 @@ import { ReviewEntityComponent } from './pages/helper/review/review-entity/revie
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { ReviewSubmitComponent } from './pages/helper/review-submit/review-submit.component';
 import {HttpErrorInterceptor} from "./http.error.interceptor";
+import {UserProfileComponent} from "./pages/user-profile/user-profile.component";
 
 @NgModule({
   declarations: [
@@ -44,7 +45,8 @@ import {HttpErrorInterceptor} from "./http.error.interceptor";
     HomeEntityComponent,
     ReviewComponent,
     ReviewEntityComponent,
-    ReviewSubmitComponent
+    ReviewSubmitComponent,
+    UserProfileComponent
   ],
   imports: [
     BrowserModule,

--- a/mediaphile/src/app/app.module.ts
+++ b/mediaphile/src/app/app.module.ts
@@ -26,7 +26,9 @@ import { ReviewEntityComponent } from './pages/helper/review/review-entity/revie
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { ReviewSubmitComponent } from './pages/helper/review-submit/review-submit.component';
 import {HttpErrorInterceptor} from "./http.error.interceptor";
-import {UserProfileComponent} from "./pages/user-profile/user-profile.component";
+import { UserProfileComponent } from "./pages/user-profile/user-profile.component";
+import { FollowListComponent } from "./pages/user-profile/follow-list/follow-list.component";
+import { FollowEntityComponent } from "./pages/user-profile/follow-list/follow-entity/follow-entity.component";
 
 @NgModule({
   declarations: [
@@ -46,7 +48,9 @@ import {UserProfileComponent} from "./pages/user-profile/user-profile.component"
     ReviewComponent,
     ReviewEntityComponent,
     ReviewSubmitComponent,
-    UserProfileComponent
+    UserProfileComponent,
+    FollowListComponent,
+    FollowEntityComponent
   ],
   imports: [
     BrowserModule,

--- a/mediaphile/src/app/info.service.ts
+++ b/mediaphile/src/app/info.service.ts
@@ -21,6 +21,7 @@ export class InfoService {
   private getBookSearch: string = `${this.apiBackendUrl}books/search`;
   private getReviews: string = `${this.apiBackendUrl}reviews`;
   private loginStatus: string = `${this.apiBackendUrl}login/status`;
+  private userEndpoint: string = `${this.apiBackendUrl}user`;
   private postQueueEndpoint: string = `${this.apiBackendUrl}list/entity`;
 
   constructor(private http: HttpClient, private router: Router, private loginStatusService: LoginStatus) {
@@ -64,6 +65,14 @@ export class InfoService {
     this.loginStatusService.sharedUrl.subscribe(x => {
       window.location.href = (x);
     })
+  }
+
+  public getUser(userId: string) {
+    return this.http.get(this.userEndpoint, {
+      params: {
+        "id": userId,
+      }
+    });
   }
 
   public postQueue(posterPath: String, id: String, type: String, title: String, entityType: String, userId: String) {

--- a/mediaphile/src/app/info.service.ts
+++ b/mediaphile/src/app/info.service.ts
@@ -23,6 +23,7 @@ export class InfoService {
   private loginStatus: string = `${this.apiBackendUrl}login/status`;
   private userEndpoint: string = `${this.apiBackendUrl}user`;
   private postQueueEndpoint: string = `${this.apiBackendUrl}list/entity`;
+  private followListEndpoint: string = `${this.apiBackendUrl}follow`;
 
   constructor(private http: HttpClient, private router: Router, private loginStatusService: LoginStatus) {
   }
@@ -112,6 +113,22 @@ export class InfoService {
         "reviewTitle": title,
         "reviewBody": reviewBody,
         "rating": String(rating)
+      }
+    })
+  }
+
+  public postFollow(userId: string, targetId: string) {
+    return this.http.post(this.followListEndpoint, {
+      "userId": userId,
+      "targetId": targetId // TODO: Ensure these names are correct
+    });
+  }
+
+  public getFollowList(userId: string, type: string) {
+    return this.http.get(this.followListEndpoint, {
+      params: {
+        "userId": userId,
+        "type": type // TODO: Ensure these names are correct
       }
     });
   }

--- a/mediaphile/src/app/pages/home/home.component.html
+++ b/mediaphile/src/app/pages/home/home.component.html
@@ -15,10 +15,12 @@
 
   <div class="tab-content" id="nav-tabContent">
     <div class="tab-pane fade show active" id="nav-queue" role="tabpanel" aria-labelledby="nav-queue-tab">
-        <app-queue [userID]="loginStatus.sharedAccountId | async" [type]="'queue'"></app-queue>
+        <app-queue [userID]="loginStatus.sharedAccountId | async"
+                   [viewerId]="loginStatus.sharedAccountId | async"[type]="'queue'"></app-queue>
     </div>
     <div class="tab-pane fade" id="nav-watched" role="tabpanel" aria-labelledby="nav-watched-tab">
-      <app-queue [userID]="loginStatus.sharedAccountId | async" [type]="'viewed'"></app-queue>
+      <app-queue [userID]="loginStatus.sharedAccountId | async"
+                 [viewerId]="loginStatus.sharedAccountId | async" [type]="'viewed'"></app-queue>
     </div>
     <div class="tab-pane fade" id="nav-profile" role="tabpanel" aria-labelledby="nav-profile-tab">
         this is a placeholder for a future section

--- a/mediaphile/src/app/pages/home/queue/queue.component.html
+++ b/mediaphile/src/app/pages/home/queue/queue.component.html
@@ -4,7 +4,7 @@
   </div>
   <div *ngIf="isEntitiesEmpty()">
     <div class = "text-center">
-      <h2><fa-icon [icon]="faEye"></fa-icon> Find some movies to add!</h2>
+      <h2><fa-icon [icon]="faEye"></fa-icon> {{getEmptyText()}}</h2>
     </div>
   </div>
 </div>

--- a/mediaphile/src/app/pages/home/queue/queue.component.ts
+++ b/mediaphile/src/app/pages/home/queue/queue.component.ts
@@ -12,10 +12,13 @@ export class QueueComponent implements OnInit {
   faEye = faEye;
 
   @Input()
-  userID: string
+  userID: string;
 
   @Input()
-  type: string
+  viewerId: string;
+
+  @Input()
+  type: string;
   public hasResults: boolean = false;
   public entities: [] = [];
   constructor(private infoSvc: InfoService) { }
@@ -33,6 +36,10 @@ export class QueueComponent implements OnInit {
 
   public isEntitiesEmpty() : boolean {
     return this.entities.length == 0;
+  }
+
+  public getEmptyText() : string {
+    return (this.userID === this.viewerId) ? "Find something to add!" : "No items added";
   }
 
 }

--- a/mediaphile/src/app/pages/user-profile/follow-list/follow-entity/follow-entity.component.html
+++ b/mediaphile/src/app/pages/user-profile/follow-list/follow-entity/follow-entity.component.html
@@ -1,0 +1,8 @@
+<div class = "entity-container">
+  <a href ="{{getEntityUrl()}}">
+    <img [src]="getEntityImageUrl()">
+    <span class = "film-title-wrapper">
+        <h3>{{getEntityTitle()}}</h3>
+    </span>
+  </a>
+</div>

--- a/mediaphile/src/app/pages/user-profile/follow-list/follow-entity/follow-entity.component.scss
+++ b/mediaphile/src/app/pages/user-profile/follow-list/follow-entity/follow-entity.component.scss
@@ -1,0 +1,56 @@
+img {
+  width: auto;
+  height: auto;
+  max-width: 75%;
+  max-height: 75%;
+  box-shadow: 2px 2px 2px #bdbdbd;
+  margin-right:1em;
+  transition: 0.3s;
+}
+img:hover {
+  box-shadow: 4px 4px 4px #8c8c8c;
+}
+.entity-container {
+  width:100%;
+  height:300px;
+  padding: 15px 0;
+  border-bottom: 1px solid #2c3440;
+  display: block;
+  position:relative;
+  overflow:hidden;
+}
+
+h3 {
+  white-space: nowrap;
+  display:inline;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 1.69230769rem;
+}
+
+h6 {
+  white-space: nowrap;
+  display: inline;
+  font-size: 1.38461538rem;
+  font-weight: 400;
+  margin-left:1em;
+  color: #596270;
+}
+span {
+  overflow-wrap: break-word;
+}
+
+a {
+  color: inherit;
+}
+
+@media (max-width: 1100px) {
+  h3 {
+    font-size: 1.39230769em;
+  }
+}
+@media (max-width: 480px) {
+  h3 {
+    font-size: 1.0769em;
+  }
+}

--- a/mediaphile/src/app/pages/user-profile/follow-list/follow-entity/follow-entity.component.spec.ts
+++ b/mediaphile/src/app/pages/user-profile/follow-list/follow-entity/follow-entity.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FollowEntityComponent } from './follow-entity.component';
+
+describe('HomeEntityComponent', () => {
+  let component: FollowEntityComponent;
+  let fixture: ComponentFixture<FollowEntityComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ FollowEntityComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(FollowEntityComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/mediaphile/src/app/pages/user-profile/follow-list/follow-entity/follow-entity.component.ts
+++ b/mediaphile/src/app/pages/user-profile/follow-list/follow-entity/follow-entity.component.ts
@@ -1,0 +1,56 @@
+import {Component, Input, OnInit} from '@angular/core';
+
+@Component({
+  selector: 'app-follow-entity',
+  templateUrl: './follow-entity.component.html',
+  styleUrls: ['./follow-entity.component.scss']
+})
+export class FollowEntityComponent implements OnInit {
+
+  @Input()
+  entity: {} = {}
+  type: string
+
+  constructor() { }
+
+  ngOnInit(): void {
+    if (this.entity["type"] != undefined){
+      this.type = this.entity["type"]
+    }
+    console.log(this.entity);
+    console.log(this.getEntityUrl())
+  }
+  public getEntityImageUrl() : string {
+    if(this.entity["artUrl"]) {
+      return "https://image.tmdb.org/t/p/w500" + this.entity['artUrl']
+    }
+    return "https://critics.io/img/movies/poster-placeholder.png"
+  }
+
+  public getReleaseYear() : string {
+    if(this.type == "movie") {
+      if(this.entity["release_date"]) {
+        return this.entity["release_date"].slice(0,4);
+      }
+    } else if(this.type == "book") {
+      if(this.entity["volumeInfo"]["publishedDate"]) {
+        return this.entity["volumeInfo"]["publishedDate"].slice(0,4);
+      }
+    }
+    return "N/A"
+  }
+
+  public getEntityUrl() : string {
+    if(this.type == "book") {
+      return `/book/${this.entity["entityId"]}`
+    } else if(this.type == "movie") {
+      return `/movie/${this.entity["entityId"]}`
+    }
+  }
+
+  public getEntityTitle() : string {
+    if(this.entity["title"]) {
+      return this.entity["title"];
+    }
+  }
+}

--- a/mediaphile/src/app/pages/user-profile/follow-list/follow-list.component.html
+++ b/mediaphile/src/app/pages/user-profile/follow-list/follow-list.component.html
@@ -1,0 +1,10 @@
+<div *ngIf = "hasReceivedResults()">
+  <div *ngFor="let entry of entities">
+    <app-follow-entity [entity]="entry"></app-follow-entity>
+  </div>
+  <div *ngIf="isEntitiesEmpty()">
+    <div class = "text-center">
+      <h2><fa-icon [icon]="faEye"></fa-icon> {{getEmptyText()}}</h2>
+    </div>
+  </div>
+</div>

--- a/mediaphile/src/app/pages/user-profile/follow-list/follow-list.component.scss
+++ b/mediaphile/src/app/pages/user-profile/follow-list/follow-list.component.scss
@@ -1,0 +1,3 @@
+h2 {
+  margin-top:2em;
+}

--- a/mediaphile/src/app/pages/user-profile/follow-list/follow-list.component.spec.ts
+++ b/mediaphile/src/app/pages/user-profile/follow-list/follow-list.component.spec.ts
@@ -1,0 +1,33 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FollowListComponent } from './follow-list.component';
+import {InfoService} from "../../../info.service";
+import {HttpClient, HttpHandler} from "@angular/common/http";
+import {Router} from "@angular/router";
+import {RouterTestingModule} from "@angular/router/testing";
+import {HttpClientTestingModule} from "@angular/common/http/testing";
+import {LoginStatus} from "../../../auth/login.status";
+
+describe('QueueComponent', () => {
+  let component: FollowListComponent;
+  let fixture: ComponentFixture<FollowListComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ FollowListComponent ],
+      imports: [ HttpClientTestingModule, RouterTestingModule.withRoutes([])],
+      providers: [InfoService, LoginStatus]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(FollowListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/mediaphile/src/app/pages/user-profile/follow-list/follow-list.component.ts
+++ b/mediaphile/src/app/pages/user-profile/follow-list/follow-list.component.ts
@@ -1,0 +1,50 @@
+import {Component, Input, OnInit} from '@angular/core';
+import {InfoService} from "../../../info.service";
+import {faEye} from "@fortawesome/free-solid-svg-icons";
+
+@Component({
+  selector: 'app-follow-list',
+  templateUrl: './follow-list.component.html',
+  styleUrls: ['./follow-list.component.scss']
+})
+export class FollowListComponent implements OnInit {
+
+  faEye = faEye;
+
+  @Input()
+  userID: string;
+
+  @Input()
+  viewerId: string;
+
+  @Input()
+  type: string;
+  public hasResults: boolean = false;
+  public entities: [] = [];
+  constructor(private infoSvc: InfoService) { }
+
+  ngOnInit(): void {
+    this.infoSvc.getFollowList(this.userID, this.type).subscribe(x => {
+      this.entities.push.apply(this.entities, x)
+      this.hasResults = true;
+    })
+  }
+
+  public hasReceivedResults() {
+    return this.hasResults;
+  }
+
+  public isEntitiesEmpty() : boolean {
+    return this.entities.length == 0;
+  }
+
+  public getEmptyText() : string {
+    if (this.type == "followers") {
+      return (this.userID === this.viewerId) ? "Find someone to follow!" : "No followers";
+    } else if (this.type == "following") {
+      return "Not following anyone";
+    }
+    return "";
+  }
+
+}

--- a/mediaphile/src/app/pages/user-profile/user-profile.component.html
+++ b/mediaphile/src/app/pages/user-profile/user-profile.component.html
@@ -14,7 +14,7 @@
   <nav>
     <div class="nav nav-tabs" id="nav-tab" role="tablist">
       <a class="nav-item nav-link active" id="nav-queue-tab" data-toggle="tab" href="#nav-queue" role="tab" aria-controls="nav-queue" aria-selected="true">
-        <fa-icon [icon]="clock"></fa-icon> <span class = "text-header"> Your Queue </span>
+        <fa-icon [icon]="clock"></fa-icon> <span class = "text-header"> {{(isSelf) ? "Your" : ""}} Queue </span>
       </a>
       <a class="nav-item nav-link" id="nav-watched-tab" data-toggle="tab" href="#nav-watched" role="tab" aria-controls="nav-watched" aria-selected="false">
         <fa-icon [icon]="clipCheck"></fa-icon> <span class = "text-header"> Watched List </span>
@@ -24,10 +24,12 @@
 
   <div class="tab-content" id="nav-tabContent">
     <div class="tab-pane fade show active" id="nav-queue" role="tabpanel" aria-labelledby="nav-queue-tab">
-      <app-queue [userID]="profileId" [type]="'queue'"></app-queue>
+      <app-queue [userID]="profileId"
+                 [viewerId]="loginStatus.sharedAccountId | async" [type]="'queue'"></app-queue>
     </div>
     <div class="tab-pane fade" id="nav-watched" role="tabpanel" aria-labelledby="nav-watched-tab">
-      <app-queue [userID]="profileId" [type]="'viewed'"></app-queue>
+      <app-queue [userID]="profileId"
+                 [viewerId]="loginStatus.sharedAccountId | async" [type]="'viewed'"></app-queue>
     </div>
   </div>
 </div>

--- a/mediaphile/src/app/pages/user-profile/user-profile.component.html
+++ b/mediaphile/src/app/pages/user-profile/user-profile.component.html
@@ -17,7 +17,7 @@
         <fa-icon [icon]="clock"></fa-icon> <span class = "text-header"> {{(isSelf) ? "Your" : ""}} Queue </span>
       </a>
       <a class="nav-item nav-link" id="nav-watched-tab" data-toggle="tab" href="#nav-watched" role="tab" aria-controls="nav-watched" aria-selected="false">
-        <fa-icon [icon]="clipCheck"></fa-icon> <span class = "text-header"> Watched List </span>
+        <fa-icon [icon]="clipCheck"></fa-icon> <span class = "text-header"> Read/Watched List </span>
       </a>
       <a class="nav-item nav-link" id="nav-following-tab" data-toggle="tab" href="#nav-following" role="tab" aria-controls="nav-watched" aria-selected="false">
         <fa-icon [icon]="heart"></fa-icon> <span class = "text-header"> Following </span>

--- a/mediaphile/src/app/pages/user-profile/user-profile.component.html
+++ b/mediaphile/src/app/pages/user-profile/user-profile.component.html
@@ -19,6 +19,12 @@
       <a class="nav-item nav-link" id="nav-watched-tab" data-toggle="tab" href="#nav-watched" role="tab" aria-controls="nav-watched" aria-selected="false">
         <fa-icon [icon]="clipCheck"></fa-icon> <span class = "text-header"> Watched List </span>
       </a>
+      <a class="nav-item nav-link" id="nav-following-tab" data-toggle="tab" href="#nav-following" role="tab" aria-controls="nav-watched" aria-selected="false">
+        <fa-icon [icon]="heart"></fa-icon> <span class = "text-header"> Following </span>
+      </a>
+      <a class="nav-item nav-link" id="nav-followers-tab" data-toggle="tab" href="#nav-followers" role="tab" aria-controls="nav-watched" aria-selected="false">
+        <fa-icon [icon]="friends"></fa-icon> <span class = "text-header"> Followers </span>
+      </a>
     </div>
   </nav>
 
@@ -30,6 +36,14 @@
     <div class="tab-pane fade" id="nav-watched" role="tabpanel" aria-labelledby="nav-watched-tab">
       <app-queue [userID]="profileId"
                  [viewerId]="loginStatus.sharedAccountId | async" [type]="'viewed'"></app-queue>
+    </div>
+    <div class="tab-pane fade" id="nav-following" role="tabpanel" aria-labelledby="nav-following-tab">
+      <app-follow-list [userID]="profileId"
+                       [viewerId]="loginStatus.sharedAccountId | async" [type]="'following'"></app-follow-list>
+    </div>
+    <div class="tab-pane fade" id="nav-followers" role="tabpanel" aria-labelledby="nav-followers-tab">
+      <app-follow-list [userID]="profileId"
+                       [viewerId]="loginStatus.sharedAccountId | async" [type]="'followers'"></app-follow-list>
     </div>
   </div>
 </div>

--- a/mediaphile/src/app/pages/user-profile/user-profile.component.html
+++ b/mediaphile/src/app/pages/user-profile/user-profile.component.html
@@ -1,0 +1,33 @@
+<div class="container" *ngIf="hasResults">
+  <div class="jumbotron">
+    <div class="container row">
+      <div id="profile-pic-container" [style.background-color]="getProfileColor()">
+        <img *ngIf="hasProfilePic()" [src]="entity['profilePicUrl']" alt="Profile Picture" />
+        <div id="profile-pic-char" *ngIf="!hasProfilePic()" [style.color]="getContrastingColor()">
+          {{getProfilePicChar()}}
+        </div>
+      </div>
+      <h1 class="col-md-1 align-self-center">{{entity['username']}}</h1>
+    </div>
+  </div>
+
+  <nav>
+    <div class="nav nav-tabs" id="nav-tab" role="tablist">
+      <a class="nav-item nav-link active" id="nav-queue-tab" data-toggle="tab" href="#nav-queue" role="tab" aria-controls="nav-queue" aria-selected="true">
+        <fa-icon [icon]="clock"></fa-icon> <span class = "text-header"> Your Queue </span>
+      </a>
+      <a class="nav-item nav-link" id="nav-watched-tab" data-toggle="tab" href="#nav-watched" role="tab" aria-controls="nav-watched" aria-selected="false">
+        <fa-icon [icon]="clipCheck"></fa-icon> <span class = "text-header"> Watched List </span>
+      </a>
+    </div>
+  </nav>
+
+  <div class="tab-content" id="nav-tabContent">
+    <div class="tab-pane fade show active" id="nav-queue" role="tabpanel" aria-labelledby="nav-queue-tab">
+      <app-queue [userID]="profileId" [type]="'queue'"></app-queue>
+    </div>
+    <div class="tab-pane fade" id="nav-watched" role="tabpanel" aria-labelledby="nav-watched-tab">
+      <app-queue [userID]="profileId" [type]="'viewed'"></app-queue>
+    </div>
+  </div>
+</div>

--- a/mediaphile/src/app/pages/user-profile/user-profile.component.scss
+++ b/mediaphile/src/app/pages/user-profile/user-profile.component.scss
@@ -1,0 +1,26 @@
+nav {
+  margin-top: 2em;
+}
+
+span {
+  display: inline;
+}
+
+@media only screen and (max-width: 768px) {
+  span {
+    display:none;
+  }
+}
+
+#profile-pic-container {
+  background-color: rgb(17, 164, 209);
+  border-radius: 5px;
+  width: 125px;
+  height: 125px;
+}
+
+#profile-pic-char {
+  font-size: 50px;
+  line-height: 115px;
+  text-align: center;
+}

--- a/mediaphile/src/app/pages/user-profile/user-profile.component.spec.ts
+++ b/mediaphile/src/app/pages/user-profile/user-profile.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { UserProfileComponent } from './user-profile.component';
+
+describe('UserProfileComponent', () => {
+  let component: UserProfileComponent;
+  let fixture: ComponentFixture<UserProfileComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ UserProfileComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(UserProfileComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/mediaphile/src/app/pages/user-profile/user-profile.component.ts
+++ b/mediaphile/src/app/pages/user-profile/user-profile.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import {LoginStatus} from "../../auth/login.status";
 import {Title} from "@angular/platform-browser";
-import {faClipboardCheck, faClock, faUserFriends} from "@fortawesome/free-solid-svg-icons";
+import {faClipboardCheck, faClock, faHeart, faUserFriends} from "@fortawesome/free-solid-svg-icons";
 import {InfoService} from "../../info.service";
 import {ActivatedRoute} from "@angular/router";
 import {Observable} from "rxjs";
@@ -15,6 +15,7 @@ export class UserProfileComponent implements OnInit {
 
   clock = faClock;
   clipCheck = faClipboardCheck;
+  heart = faHeart;
   friends = faUserFriends;
 
   public userId: string;

--- a/mediaphile/src/app/pages/user-profile/user-profile.component.ts
+++ b/mediaphile/src/app/pages/user-profile/user-profile.component.ts
@@ -4,6 +4,7 @@ import {Title} from "@angular/platform-browser";
 import {faClipboardCheck, faClock, faUserFriends} from "@fortawesome/free-solid-svg-icons";
 import {InfoService} from "../../info.service";
 import {ActivatedRoute} from "@angular/router";
+import {Observable} from "rxjs";
 
 @Component({
   selector: 'app-user-profile',
@@ -16,8 +17,9 @@ export class UserProfileComponent implements OnInit {
   clipCheck = faClipboardCheck;
   friends = faUserFriends;
 
-  private userId: string;
+  public userId: string;
   public profileId: string;
+  public isSelf: boolean;
 
   public entity: {};
   public hasResults: boolean;
@@ -30,20 +32,29 @@ export class UserProfileComponent implements OnInit {
   ngOnInit(): void {
     this.title.setTitle(`Mediaphile :: Profile`)
 
-    this.loginStatus.sharedAccountId.subscribe(userId => {
-      this.userId = userId;
-    });
-
     if (this.route.snapshot.paramMap.get("id") != undefined) {
       this.profileId = this.route.snapshot.paramMap.get("id");
     }
+
     if(this.profileId != null) {
       this.infoSvc.getUser(this.profileId).subscribe(data => {
         this.entity = data;
         this.hasResults = true;
-        this.title.setTitle(`Mediaphile :: ${this.entity['username']} Profile`)
+
+        this.subscribeSelf();
       });
+    } else {
+      this.subscribeSelf();
     }
+  }
+
+  subscribeSelf() {
+    this.loginStatus.sharedAccountId.subscribe(userId => {
+      this.userId = userId;
+      this.isSelf = (this.userId === this.profileId);
+      let whose = (this.isSelf) ? "" : (this.entity['username'] + "'s ");
+      this.title.setTitle(`Mediaphile :: ${whose}Profile`);
+    });
   }
 
   hasProfilePic() : boolean {

--- a/mediaphile/src/app/pages/user-profile/user-profile.component.ts
+++ b/mediaphile/src/app/pages/user-profile/user-profile.component.ts
@@ -1,0 +1,90 @@
+import { Component, OnInit } from '@angular/core';
+import {LoginStatus} from "../../auth/login.status";
+import {Title} from "@angular/platform-browser";
+import {faClipboardCheck, faClock, faUserFriends} from "@fortawesome/free-solid-svg-icons";
+import {InfoService} from "../../info.service";
+import {ActivatedRoute} from "@angular/router";
+
+@Component({
+  selector: 'app-user-profile',
+  templateUrl: './user-profile.component.html',
+  styleUrls: ['./user-profile.component.scss']
+})
+export class UserProfileComponent implements OnInit {
+
+  clock = faClock;
+  clipCheck = faClipboardCheck;
+  friends = faUserFriends;
+
+  private userId: string;
+  public profileId: string;
+
+  public entity: {};
+  public hasResults: boolean;
+
+  private profileColor: string;
+
+  constructor(public loginStatus: LoginStatus, private title: Title,
+              private infoSvc: InfoService, private route: ActivatedRoute) { }
+
+  ngOnInit(): void {
+    this.title.setTitle(`Mediaphile :: Profile`)
+
+    this.loginStatus.sharedAccountId.subscribe(userId => {
+      this.userId = userId;
+    });
+
+    if (this.route.snapshot.paramMap.get("id") != undefined) {
+      this.profileId = this.route.snapshot.paramMap.get("id");
+    }
+    if(this.profileId != null) {
+      this.infoSvc.getUser(this.profileId).subscribe(data => {
+        this.entity = data;
+        this.hasResults = true;
+        this.title.setTitle(`Mediaphile :: ${this.entity['username']} Profile`)
+      });
+    }
+  }
+
+  hasProfilePic() : boolean {
+    return this.entity['profilePicUrl'] !== "";
+  }
+
+  getProfilePicChar() : string {
+    return this.entity['username'].charAt(0).toLocaleUpperCase();
+  }
+
+  private static hashProfileId(str) : number {
+    let hash = 0;
+    for (let i = 0; i < str.length; i++) {
+      hash = str.charCodeAt(i) + ((hash << 5) - hash);
+    }
+    return hash;
+  }
+
+  private static hexToRgb(hex) : {} {
+    let result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+    return result ? {
+      r: parseInt(result[1], 16),
+      g: parseInt(result[2], 16),
+      b: parseInt(result[3], 16)
+    } : null;
+  }
+
+  getProfileColor() : string {
+    let hash = UserProfileComponent.hashProfileId(this.profileId);
+    let encoded = (hash & 0x00FFFFFF).toString(16).toUpperCase();
+    this.profileColor = "#" + "00000".substring(0, 6 - encoded.length) + encoded;
+    return this.profileColor;
+  }
+
+  getContrastingColor() {
+    if (!this.profileColor) this.getProfileColor();
+    let rgb = UserProfileComponent.hexToRgb(this.profileColor);
+    const brightness = Math.round(((parseInt(rgb['r']) * 299) +
+      (parseInt(rgb['g']) * 587) +
+      (parseInt(rgb['b']) * 114)) / 1000);
+
+    return (brightness > 125) ? '#000000' : '#FFFFFF';
+  }
+}


### PR DESCRIPTION
# Completed so far
## app/pages/user-profile/user-profile.component.ts
- Provides a profile page as shown in the images section
- Contains a header with a generated profile picture and the user's username
    - The profile picture is the first character of the username, capitalized
    - The background color is generated from a hash of the user's ID
    - The character's foreground color is black or white, depending on the brightness of the background color
- Includes fully working queue and viewed list
- Includes placeholder following and followers lists
    - **These should work as soon as:** 
        - The followers backend is merged
        - `info.service.ts` is checked to ensure it matches the backend schema
        - The `follow-entity` component is integrated with the schema 

## app/pages/home/queue/queue.component.ts
- Revised the text shown when a list is empty
    - Will now say "Find something to add" only if the user is viewing their own queue
    - Will say "Nothing added" otherwise
- The queue lists on the home and profile pages now say "Your Queue" iff the user is viewing their own queue, else just "Queue"

# Prepared for completion
## app/pages/user-profile/follow-list/follow-entity/follow-entity.component.*
- Currently a direct copy of `home-entity`
- To be replaced once the data output of the `follow` endpoint is well-defined
- The design and pagination will be discussed leading up to that

# Images
![image](https://user-images.githubusercontent.com/30727195/87817547-28b61700-c837-11ea-92fa-ed355eb352a3.png)

Edit: "Watched List" has been changed to "Read/Watched List"