### PR TITLE
Fixes Production Routing Issues

### DIFF
--- a/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/src/main/webapp/WEB-INF/appengine-web.xml
@@ -3,12 +3,8 @@
     <threadsafe>false</threadsafe>
     <sessions-enabled>true</sessions-enabled>
     <runtime>java8</runtime>
-    <service>api</service>
     <static-files>
         <!-- prevent unwanted caching when accessing via the web preview server -->
         <include path="/**" expiration="0s" />
     </static-files>
-    <static-error-handlers>
-        <handler file="index.html" />
-    </static-error-handlers>
 </appengine-web-app>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -11,33 +11,32 @@
         <filter-name>ObjectifyFilter</filter-name>
         <url-pattern>*</url-pattern>
     </filter-mapping>
-
     <servlet>
-        <servlet-name>html-mapping</servlet-name>
-        <jsp-file>/index.html</jsp-file>
+        <servlet-name>StaticServlet</servlet-name>
+        <jsp-file>/index.jsp</jsp-file>
     </servlet>
     <servlet-mapping>
-        <servlet-name>html-mapping</servlet-name>
+        <servlet-name>StaticServlet</servlet-name>
         <url-pattern>/home/*</url-pattern>
     </servlet-mapping>
     <servlet-mapping>
-        <servlet-name>html-mapping</servlet-name>
+        <servlet-name>StaticServlet</servlet-name>
         <url-pattern>/movie/*</url-pattern>
     </servlet-mapping>
     <servlet-mapping>
-        <servlet-name>html-mapping</servlet-name>
+        <servlet-name>StaticServlet</servlet-name>
         <url-pattern>/book/*</url-pattern>
     </servlet-mapping>
     <servlet-mapping>
-        <servlet-name>html-mapping</servlet-name>
+        <servlet-name>StaticServlet</servlet-name>
         <url-pattern>/search/*</url-pattern>
     </servlet-mapping>
     <servlet-mapping>
-        <servlet-name>html-mapping</servlet-name>
+        <servlet-name>StaticServlet</servlet-name>
         <url-pattern>/user/*</url-pattern>
     </servlet-mapping>
     <servlet-mapping>
-        <servlet-name>html-mapping</servlet-name>
+        <servlet-name>StaticServlet</servlet-name>
         <url-pattern>/login</url-pattern>
     </servlet-mapping>
 </web-app>

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -1,0 +1,1 @@
+<%@ include file="index.html" %>


### PR DESCRIPTION
Found a workaround for the `index.html` routing issue.

## Issue
On production builds of the server, the `web.xml` behaves a little differently from what happens locally. I imagine this has to be due with the way Appengine handles servlets. The routing would be fine locally, but would fail on production.

## Fix?
This PR fixes this by rendering out a .jsp version of the HTML file, this renders properly and will require no changes from the Ci / CD or locally building.