### PR TITLE
Implements Recent Activity and Refactors Entity Results

### DIFF
--- a/mediaphile/src/app/app.module.ts
+++ b/mediaphile/src/app/app.module.ts
@@ -30,6 +30,8 @@ import { UserProfileComponent } from "./pages/user-profile/user-profile.componen
 import { FollowListComponent } from "./pages/user-profile/follow-list/follow-list.component";
 import { FollowEntityComponent } from "./pages/user-profile/follow-list/follow-entity/follow-entity.component";
 import { ModalComponent } from './pages/helper/modal/modal.component';
+import { ActivityComponent } from './pages/home/activity/activity.component';
+import { ActivityEntityComponent } from './pages/home/activity/activity-entity/activity-entity.component';
 
 @NgModule({
   declarations: [
@@ -52,7 +54,9 @@ import { ModalComponent } from './pages/helper/modal/modal.component';
     UserProfileComponent,
     FollowListComponent,
     FollowEntityComponent,
-    ModalComponent
+    ModalComponent,
+    ActivityComponent,
+    ActivityEntityComponent
   ],
   imports: [
     BrowserModule,

--- a/mediaphile/src/app/info.service.ts
+++ b/mediaphile/src/app/info.service.ts
@@ -25,6 +25,7 @@ export class InfoService {
   private postQueueEndpoint: string = `${this.apiBackendUrl}list/entity`;
   private followListEndpoint: string = `${this.apiBackendUrl}follow`;
   private getBookDetailsEndpoint: string = `${this.apiBackendUrl}books/details`;
+  private getActivityEndpoint: string = `${this.apiBackendUrl}activity/followers`;
 
   constructor(private http: HttpClient, private router: Router, private loginStatusService: LoginStatus) {
   }
@@ -148,6 +149,15 @@ export class InfoService {
         mediaId: mediaId,
         listType: listType,
         mediaType: mediaType
+      }
+    })
+  }
+
+  public getActivity(userId: string, offset: number) {
+    return this.http.get<{}[]>(this.getActivityEndpoint, {
+      params: {
+        userId: userId,
+        offset: String(offset)
       }
     })
   }

--- a/mediaphile/src/app/pages/book-details/book-details.component.html
+++ b/mediaphile/src/app/pages/book-details/book-details.component.html
@@ -44,12 +44,13 @@
       </div>
     </div>
   </main>
+  <div #reviews class = "container reviews">
+    <h2>Reviews: </h2>
+    <app-review [type]="'book'" [id]="bookId"  [title]="bookData['volumeInfo']['title']" [artUrl]="getEntityPosterUrl()"></app-review>
+  </div>
 </div>
 
-<div #reviews *ngIf="bookData != undefined" class = "container reviews">
-  <h2>Reviews: </h2>
-  <app-review [type]="'book'" [id]="bookId"  [title]="bookData['volumeInfo']['title']" [artUrl]="getEntityPosterUrl()"></app-review>
-</div>
+
 
 <ng-template #loading>
   <div class="d-flex justify-content-center loader">

--- a/mediaphile/src/app/pages/book-details/book-details.component.html
+++ b/mediaphile/src/app/pages/book-details/book-details.component.html
@@ -44,11 +44,11 @@
       </div>
     </div>
   </main>
-</div>
 
-<div #reviews class = "container reviews">
-  <h2>Reviews: </h2>
-  <app-review *ngIf="this.entity | async" [type]="'book'" [id]="bookId"  [title]="getEntityTitle()" [artUrl]="getEntityPosterUrl()"></app-review>
+  <div #reviews class = "container reviews">
+    <h2>Reviews: </h2>
+    <app-review *ngIf="this.entity | async" [type]="'book'" [id]="bookId"  [title]="getEntityTitle()" [artUrl]="getEntityPosterUrl()"></app-review>
+  </div>
 </div>
 
 <ng-template #loading>

--- a/mediaphile/src/app/pages/helper/review/review-entity/review-entity.component.html
+++ b/mediaphile/src/app/pages/helper/review/review-entity/review-entity.component.html
@@ -1,5 +1,5 @@
 <div class = "container">
-  <a href = "user/{{review.authorId}}" class = "author-name">{{review.authorName}}</a>
+  <a href = "user/{{review.userId}}" class = "author-name">{{review.authorName}}</a>
   <span> rated it </span>
 
   <ngb-rating  [(rate)]="currentRate" [max]="5" [readonly]=true>

--- a/mediaphile/src/app/pages/helper/review/review-entity/review-entity.component.spec.ts
+++ b/mediaphile/src/app/pages/helper/review/review-entity/review-entity.component.spec.ts
@@ -21,7 +21,7 @@ describe('ReviewEntityComponent', () => {
     component.review = {
       id: 3,
       timestamp: "1234",
-      authorId: "5678",
+      userId: "5678",
       authorName: "Chris",
       contentType: "book",
       contentId: "12345",

--- a/mediaphile/src/app/pages/home/activity/activity-entity/activity-entity.component.html
+++ b/mediaphile/src/app/pages/home/activity/activity-entity/activity-entity.component.html
@@ -1,0 +1,29 @@
+<div *ngIf = "isReview()" class = "activity-container">
+  <div class="row">
+    <div class="col-3">
+      <img [src]="getArtwork()">
+    </div>
+
+    <div class="col-9">
+      <span class = "activity-text-container">
+         <a href = "{{getAuthorUrl()}}">{{getAuthor()}}</a> rated <a href = "{{getActivityUrl()}}"><div class = "entity-title">{{getTitle()}}</div></a> {{this.getRating()}} stars!
+      </span>
+    </div>
+
+  </div>
+</div>
+
+<div *ngIf = "!isReview()" class = "activity-container">
+  <div class="row">
+    <div class="col-3">
+      <img [src]="getArtwork()">
+    </div>
+
+    <div class="col-9">
+      <span class = "activity-text-container">
+        <a href = "{{getAuthorUrl()}}">{{getAuthor()}}</a> added <a href = "{{getActivityUrl()}}"><div class = "entity-title">{{getTitle()}}</div></a> to their "{{getListType()}}" list
+      </span>
+    </div>
+
+  </div>
+</div>

--- a/mediaphile/src/app/pages/home/activity/activity-entity/activity-entity.component.scss
+++ b/mediaphile/src/app/pages/home/activity/activity-entity/activity-entity.component.scss
@@ -1,0 +1,46 @@
+.activity-container {
+  min-height:150px;
+  width:80%;
+  margin-bottom:2em;
+  border-bottom: 1px solid #e1e4e8!important;
+  padding:.1em;
+}
+
+.activity-text-container {
+  text-align: justify;
+  padding: 0 1em;
+}
+
+img {
+  outline: 1px solid #000;
+  display: block;
+  max-width:85%;
+  max-height:144px;
+  margin:auto;
+}
+
+.entity-title {
+  font-family: "Merriweather", "Georgia", serif;
+  font-weight: bold;
+  display:inline;
+  color: initial !important;
+}
+
+.col-3 {
+  height:100%;
+  box-sizing:border-box;
+  display: flex;
+}
+.col-9 {
+  display: flex;
+  align-items: center;
+}
+.row {
+  height:100%;
+}
+
+@media only screen and (max-width: 768px) {
+  .activity-container{
+    width:100% !important;
+  }
+}

--- a/mediaphile/src/app/pages/home/activity/activity-entity/activity-entity.component.spec.ts
+++ b/mediaphile/src/app/pages/home/activity/activity-entity/activity-entity.component.spec.ts
@@ -1,6 +1,11 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ActivityEntityComponent } from './activity-entity.component';
+import {HttpClientTestingModule} from "@angular/common/http/testing";
+import {RouterTestingModule} from "@angular/router/testing";
+import {InfoService} from "../../../../info.service";
+import {HttpClient} from "@angular/common/http";
+import {LoginStatus} from "../../../../auth/login.status";
 
 describe('ActivityEntityComponent', () => {
   let component: ActivityEntityComponent;
@@ -8,7 +13,9 @@ describe('ActivityEntityComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ ActivityEntityComponent ]
+      declarations: [ ActivityEntityComponent ],
+      imports: [HttpClientTestingModule, RouterTestingModule.withRoutes([])],
+      providers: [InfoService, HttpClient, LoginStatus]
     })
     .compileComponents();
   }));
@@ -16,6 +23,9 @@ describe('ActivityEntityComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(ActivityEntityComponent);
     component = fixture.componentInstance;
+    component.activity = {
+      "artUrl": "coolUrl.com"
+    }
     fixture.detectChanges();
   });
 

--- a/mediaphile/src/app/pages/home/activity/activity-entity/activity-entity.component.spec.ts
+++ b/mediaphile/src/app/pages/home/activity/activity-entity/activity-entity.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ActivityEntityComponent } from './activity-entity.component';
+
+describe('ActivityEntityComponent', () => {
+  let component: ActivityEntityComponent;
+  let fixture: ComponentFixture<ActivityEntityComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ActivityEntityComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ActivityEntityComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/mediaphile/src/app/pages/home/activity/activity-entity/activity-entity.component.ts
+++ b/mediaphile/src/app/pages/home/activity/activity-entity/activity-entity.component.ts
@@ -22,10 +22,8 @@ export class ActivityEntityComponent implements OnInit {
   }
 
   public getArtwork() {
-    if(this.isReview()) {
-      if (this.activity["contentType"] != "book") {
+    if(this.isReview() && (this.activity["contentType"] === "movie")) {
         return "https://image.tmdb.org/t/p/w500" + this.activity["artUrl"]
-      }
     }
     return this.activity["artUrl"];
   }

--- a/mediaphile/src/app/pages/home/activity/activity-entity/activity-entity.component.ts
+++ b/mediaphile/src/app/pages/home/activity/activity-entity/activity-entity.component.ts
@@ -1,0 +1,81 @@
+import {Component, Input, OnInit} from '@angular/core';
+
+@Component({
+  selector: 'app-activity-entity',
+  templateUrl: './activity-entity.component.html',
+  styleUrls: ['./activity-entity.component.scss']
+})
+export class ActivityEntityComponent implements OnInit {
+
+  @Input()
+
+  activity: Object
+
+  constructor() { }
+
+  ngOnInit(): void {
+
+  }
+
+  public isReview(): boolean {
+    return "reviewTitle" in this.activity
+  }
+
+  public getArtwork() {
+    if(this.isReview()) {
+      if (this.activity["contentType"] != "book") {
+        return "https://image.tmdb.org/t/p/w500" + this.activity["artUrl"]
+      }
+    }
+    return this.activity["artUrl"];
+  }
+
+  public getTitle(): string {
+    if(this.isReview()) {
+      return this.activity["contentTitle"]
+    }
+    return this.activity["title"]
+  }
+
+  public getAuthor(): string {
+    if(this.isReview()) {
+      return this.activity["authorName"];
+    }
+    return "Someone you follow "
+  }
+
+  public getRating() : string {
+    if(this.isReview()) {
+      return this.activity["rating"]
+    }
+    return ""
+  }
+
+  public getListType() : string {
+    if(!this.isReview()) {
+      return this.activity["listType"]
+    }
+    return ""
+  }
+
+  public getActivityMessage(): string {
+    if(this.isReview()) {
+      return `${this.getAuthor()} rated "${this.getTitle()}" ${this.getRating()} stars!`
+    }
+    return `${this.getAuthor()} added ${this.getTitle()} to their "${this.getListType()}" list`
+  }
+
+  public getActivityUrl(): string {
+    if(this.isReview()) {
+      return `${this.activity["contentType"]}/${this.activity["contentId"]}`
+    }
+    return `${this.activity["mediaType"]}/${this.activity["mediaId"]}`
+  }
+
+  public getAuthorUrl(): string {
+    if(this.isReview()) {
+      return "/user/" + this.activity["authorId"]
+    }
+    return "/user/" + this.activity["userId"]
+  }
+}

--- a/mediaphile/src/app/pages/home/activity/activity-entity/activity-entity.component.ts
+++ b/mediaphile/src/app/pages/home/activity/activity-entity/activity-entity.component.ts
@@ -24,9 +24,6 @@ export class ActivityEntityComponent implements OnInit {
   }
 
   public getArtwork() {
-    if(this.isReview() && (this.activity["contentType"] === "movie")) {
-        return "https://image.tmdb.org/t/p/w500" + this.activity["artUrl"]
-    }
     return this.activity["artUrl"];
   }
 

--- a/mediaphile/src/app/pages/home/activity/activity-entity/activity-entity.component.ts
+++ b/mediaphile/src/app/pages/home/activity/activity-entity/activity-entity.component.ts
@@ -18,7 +18,9 @@ export class ActivityEntityComponent implements OnInit {
   }
 
   public isReview(): boolean {
-    return "reviewTitle" in this.activity
+    if(this.activity != null) {
+      return "reviewTitle" in this.activity
+    }
   }
 
   public getArtwork() {

--- a/mediaphile/src/app/pages/home/activity/activity.component.html
+++ b/mediaphile/src/app/pages/home/activity/activity.component.html
@@ -1,0 +1,13 @@
+<div class = "container">
+  <h2>Recent Activity: </h2>
+  <div *ngFor="let a of activity">
+    <app-activity-entity [activity]="a"></app-activity-entity>
+  </div>
+  <div (click)="loadMore()" *ngIf="showMore" class="load-more">Load More Activity</div>
+</div>
+
+<div class="text-center align-middle" *ngIf="!loaded">
+  <div class="spinner-border" role="status">
+    <span class="sr-only">Loading...</span>
+  </div>
+</div>

--- a/mediaphile/src/app/pages/home/activity/activity.component.scss
+++ b/mediaphile/src/app/pages/home/activity/activity.component.scss
@@ -1,0 +1,10 @@
+h2 {
+  margin-top:.75em;
+}
+
+.load-more {
+  margin: 1em 0;
+  font-size:1.2rem;
+  cursor: pointer;
+  text-align: center;
+}

--- a/mediaphile/src/app/pages/home/activity/activity.component.spec.ts
+++ b/mediaphile/src/app/pages/home/activity/activity.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ActivityComponent } from './activity.component';
+
+describe('ActivityComponent', () => {
+  let component: ActivityComponent;
+  let fixture: ComponentFixture<ActivityComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ActivityComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ActivityComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/mediaphile/src/app/pages/home/activity/activity.component.spec.ts
+++ b/mediaphile/src/app/pages/home/activity/activity.component.spec.ts
@@ -1,6 +1,11 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ActivityComponent } from './activity.component';
+import {HttpClientTestingModule} from "@angular/common/http/testing";
+import {RouterTestingModule} from "@angular/router/testing";
+import {InfoService} from "../../../info.service";
+import {HttpClient} from "@angular/common/http";
+import {LoginStatus} from "../../../auth/login.status";
 
 describe('ActivityComponent', () => {
   let component: ActivityComponent;
@@ -8,7 +13,9 @@ describe('ActivityComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ ActivityComponent ]
+      declarations: [ ActivityComponent ],
+      imports: [HttpClientTestingModule, RouterTestingModule.withRoutes([])],
+      providers: [InfoService, HttpClient, LoginStatus]
     })
     .compileComponents();
   }));

--- a/mediaphile/src/app/pages/home/activity/activity.component.ts
+++ b/mediaphile/src/app/pages/home/activity/activity.component.ts
@@ -1,0 +1,52 @@
+import { Component, OnInit } from '@angular/core';
+import {InfoService} from "../../../info.service";
+import {Observable} from "rxjs";
+import {LoginStatus} from "../../../auth/login.status";
+import {ModalComponent} from "../../helper/modal/modal.component";
+import {NgbModal} from "@ng-bootstrap/ng-bootstrap";
+
+@Component({
+  selector: 'app-activity',
+  templateUrl: './activity.component.html',
+  styleUrls: ['./activity.component.scss']
+})
+export class ActivityComponent implements OnInit {
+
+  public activity: {}[] = [];
+  public loaded: boolean = false;
+  public showMore: boolean = true;
+  public pageNumber: number = 0;
+  constructor(private infoSvc: InfoService, private loginStatus: LoginStatus, private modalService: NgbModal) { }
+
+  ngOnInit(): void {
+    this.getMoreActivity(0);
+  }
+
+  public getMoreActivity(offset: number) {
+    this.loaded = false;
+    this.loginStatus.sharedAccountId.subscribe(id => {
+      this.infoSvc.getActivity(id, offset).subscribe(data => {
+        this.activity.push.apply(this.activity, data)
+        if(data.length != 10) {
+          this.showMore = false;
+        }
+        this.loaded = true;
+      })
+    }, error => {
+      this.loaded = true;
+      this.showMessage("Oops", "Couldn't load activity feed!")
+    })
+  }
+
+  public showMessage(title: string, message: string) {
+    const modalRef = this.modalService.open(ModalComponent);
+    modalRef.componentInstance.title = title
+    modalRef.componentInstance.message = message
+  }
+
+  public loadMore() {
+    this.pageNumber += 10;
+    this.getMoreActivity(this.pageNumber);
+  }
+}
+

--- a/mediaphile/src/app/pages/home/home-entity/home-entity.component.scss
+++ b/mediaphile/src/app/pages/home/home-entity/home-entity.component.scss
@@ -1,11 +1,10 @@
 img {
-  width: auto;
-  height: auto;
-  max-width: 75%;
-  max-height: 75%;
+  height: 82%;
   box-shadow: 2px 2px 2px #bdbdbd;
   margin-right:1em;
   transition: 0.3s;
+  display: block;
+  margin: auto;
 }
 img:hover {
   box-shadow: 4px 4px 4px #8c8c8c;
@@ -14,7 +13,7 @@ img:hover {
   width:100%;
   height:300px;
   padding: 15px 0;
-  border-bottom: 1px solid #2c3440;
+  //border-bottom: 1px solid #2c3440;
   display: block;
   position:relative;
   overflow:hidden;
@@ -22,7 +21,8 @@ img:hover {
 
 h3 {
   white-space: nowrap;
-  display:inline;
+  display:block;
+  text-align: center;
   overflow: hidden;
   text-overflow: ellipsis;
   font-size: 1.69230769rem;

--- a/mediaphile/src/app/pages/home/home.component.html
+++ b/mediaphile/src/app/pages/home/home.component.html
@@ -23,7 +23,7 @@
                  [viewerId]="loginStatus.sharedAccountId | async" [type]="'viewed'"></app-queue>
     </div>
     <div class="tab-pane fade" id="nav-profile" role="tabpanel" aria-labelledby="nav-profile-tab">
-        this is a placeholder for a future section
+        <app-activity></app-activity>
     </div>
   </div>
 </div>

--- a/mediaphile/src/app/pages/home/queue/queue.component.html
+++ b/mediaphile/src/app/pages/home/queue/queue.component.html
@@ -1,6 +1,8 @@
-<div *ngIf = "hasReceivedResults()">
-  <div *ngFor="let entry of entities">
-    <app-home-entity [entity]="entry"></app-home-entity>
+<div class = "container" *ngIf = "hasReceivedResults()">
+  <div class="row">
+    <div *ngFor="let entry of entities" class="col-md-3">
+      <app-home-entity [entity]="entry"></app-home-entity>
+    </div>
   </div>
   <div *ngIf="isEntitiesEmpty()">
     <div class = "text-center">

--- a/mediaphile/src/app/pages/movie-details/movie-details.component.html
+++ b/mediaphile/src/app/pages/movie-details/movie-details.component.html
@@ -41,12 +41,13 @@
       </div>
     </div>
   </main>
+
+  <div #reviews class="container reviews">
+    <h2>Reviews: </h2>
+    <app-review [type]="'movie'" [id]="movieId" [title]="movieData['title']" [artUrl]="getEntityPosterUrl()"></app-review>
+  </div>
 </div>
 
-<div *ngIf="movieData != undefined" #reviews class="container reviews">
-  <h2>Reviews: </h2>
-  <app-review [type]="'movie'" [id]="movieId" [title]="entity['title']" [artUrl]="getEntityPosterUrl()"></app-review>
-</div>
 
 <ng-template #loading>
   <div class="d-flex justify-content-center loader">

--- a/mediaphile/src/app/pages/movie-details/movie-details.component.html
+++ b/mediaphile/src/app/pages/movie-details/movie-details.component.html
@@ -41,11 +41,10 @@
       </div>
     </div>
   </main>
-</div>
-
-<div #reviews class="container reviews">
-  <h2>Reviews: </h2>
-  <app-review *ngIf="this.entity | async" [type]="'movie'" [id]="movieId" [title]="entity['title']" [artUrl]="getEntityPosterUrl()"></app-review>
+  <div #reviews class="container reviews">
+    <h2>Reviews: </h2>
+    <app-review *ngIf="this.entity | async" [type]="'movie'" [id]="movieId" [title]="movieData['title']" [artUrl]="getEntityPosterUrl()"></app-review>
+  </div>
 </div>
 
 <ng-template #loading>

--- a/mediaphile/src/app/pages/search/entity/entity.component.html
+++ b/mediaphile/src/app/pages/search/entity/entity.component.html
@@ -1,9 +1,9 @@
 <div class = "entity-container">
-    <a href ="{{getEntityUrl()}}">
-      <img [src]="getEntityImageUrl()">
-      <span class = "film-title-wrapper">
+  <a href ="{{getEntityUrl()}}">
+    <img [src]="getEntityImageUrl()">
+    <span class = "film-title-wrapper">
         <h3>{{getEntityTitle()}}</h3>
         <h6>{{getReleaseYear()}}</h6>
     </span>
-    </a>
+  </a>
 </div>

--- a/mediaphile/src/app/pages/search/entity/entity.component.scss
+++ b/mediaphile/src/app/pages/search/entity/entity.component.scss
@@ -1,11 +1,11 @@
 img {
-  width: auto;
-  height: auto;
-  max-width: 75%;
-  max-height: 75%;
+  height: 82%;
   box-shadow: 2px 2px 2px #bdbdbd;
   margin-right:1em;
   transition: 0.3s;
+  display: block;
+  border: solid black 1px;
+  margin: auto;
 }
 img:hover {
   box-shadow: 4px 4px 4px #8c8c8c;
@@ -14,27 +14,30 @@ img:hover {
   width:100%;
   height:300px;
   padding: 15px 0;
-  border-bottom: 1px solid #2c3440;
   display: block;
   position:relative;
   overflow:hidden;
+  margin:.5em;
 }
 
 h3 {
   white-space: nowrap;
-  display:inline;
+  display:block;
+  text-align: center;
   overflow: hidden;
   text-overflow: ellipsis;
-  font-size: 1.69230769rem;
+  font-size: 1.39230769rem;
 }
 
 h6 {
   white-space: nowrap;
-  display: inline;
-  font-size: 1.38461538rem;
-  font-weight: 400;
-  margin-left:1em;
+  display:block;
+  text-align: center;
+  overflow: hidden;
+  text-overflow: ellipsis;
   color: #596270;
+  font-size: 1.18461538rem;
+
 }
 span {
   overflow-wrap: break-word;

--- a/mediaphile/src/app/pages/search/results/results.component.html
+++ b/mediaphile/src/app/pages/search/results/results.component.html
@@ -1,10 +1,13 @@
+<div class = "container">
   <h2>Exploring {{query}}: </h2>
   <div *ngIf="hasReceivedResults()">
     <h6>Found {{total_results}} results!</h6>
     <h6 *ngIf="type=='book'"><img src = "assets/gbs_preview_button1.png"></h6>
-
-    <div *ngFor="let entry of arrayResults">
-      <app-entity [entity]="entry" [type]="type"></app-entity>
+    <div class="row">
+      <div *ngFor="let entry of arrayResults" class="col-md-3">
+        <app-entity [entity]="entry" [type]="type"></app-entity>
+      </div>
     </div>
     <div (click)="loadMore()" *ngIf="canLoadMore" class="load-more">Load More Results <fa-icon [icon]="faAngleDoubleRight"></fa-icon></div>
   </div>
+</div>

--- a/mediaphile/src/app/struct/Review.ts
+++ b/mediaphile/src/app/struct/Review.ts
@@ -3,7 +3,7 @@ export interface Review {
 
   timestamp: string;
 
-   authorId: string;
+   userId: string;
 
    authorName: string;
 

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
     <dependency>
       <groupId>com.googlecode.objectify</groupId>
       <artifactId>objectify</artifactId>
-      <version>4.1.3</version>
+      <version>5.0</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/com/google/sps/ContextListener.java
+++ b/src/main/java/com/google/sps/ContextListener.java
@@ -1,6 +1,7 @@
 package com.google.sps;
 
 
+import com.google.sps.model.activity.Activity;
 import com.google.sps.model.queue.MediaListItem;
 import com.google.sps.model.queue.QueueListItemObject;
 import com.google.sps.model.queue.ViewedListItemObject;
@@ -38,5 +39,6 @@ public class ContextListener implements ServletContextListener {
         ObjectifyService.register(UserObject.class);
         ObjectifyService.register(ReviewObject.class);
         ObjectifyService.register(FollowItem.class);
+        ObjectifyService.register(Activity.class);
     }
 }

--- a/src/main/java/com/google/sps/model/activity/Activity.java
+++ b/src/main/java/com/google/sps/model/activity/Activity.java
@@ -1,0 +1,25 @@
+package com.google.sps.model.activity;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.googlecode.objectify.annotation.Entity;
+import com.googlecode.objectify.annotation.Id;
+import com.googlecode.objectify.annotation.Index;
+
+/**
+ * This activity interface is used to hold data for anything that would show up in the activity feed
+ */
+@Entity(name = "Activity")
+public class Activity {
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    @Id
+    @JsonProperty
+    @Index
+    private Long id;
+}

--- a/src/main/java/com/google/sps/model/queue/MediaListItem.java
+++ b/src/main/java/com/google/sps/model/queue/MediaListItem.java
@@ -1,9 +1,10 @@
 package com.google.sps.model.queue;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.sps.model.activity.Activity;
 import com.googlecode.objectify.annotation.Entity;
-import com.googlecode.objectify.annotation.Id;
 import com.googlecode.objectify.annotation.Index;
+import com.googlecode.objectify.annotation.Subclass;
 
 import java.sql.Timestamp;
 
@@ -12,8 +13,8 @@ import java.sql.Timestamp;
  * queue object or already watched object. We abstract these later as
  * to end up in different tables in the db.
  */
-@Entity
-public class MediaListItem {
+@Subclass(index=true)
+public class MediaListItem extends Activity {
 
     public static final String TYPE_VIEWED = "viewed";
     public static final String TYPE_QUEUE = "queue";
@@ -34,11 +35,6 @@ public class MediaListItem {
     @JsonProperty
     @Index
     private String mediaId;
-
-    @JsonProperty
-    @Index
-    @Id
-    private Long id;
 
     @JsonProperty
     @Index
@@ -74,14 +70,6 @@ public class MediaListItem {
 
     public void setMediaType(String mediaType) {
         this.mediaType = mediaType;
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
     }
 
     public String getMediaId() {

--- a/src/main/java/com/google/sps/model/queue/MediaListItem.java
+++ b/src/main/java/com/google/sps/model/queue/MediaListItem.java
@@ -56,6 +56,10 @@ public class MediaListItem {
     @Index
     private String userId;
 
+    @JsonProperty
+    @Index
+    private String username;
+
     public String getTitle() {
         return title;
     }
@@ -118,5 +122,13 @@ public class MediaListItem {
 
     public void setListType(String listType) {
         this.listType = listType;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
     }
 }

--- a/src/main/java/com/google/sps/model/queue/QueueListItemObject.java
+++ b/src/main/java/com/google/sps/model/queue/QueueListItemObject.java
@@ -1,10 +1,11 @@
 package com.google.sps.model.queue;
 
 import com.googlecode.objectify.annotation.Entity;
+import com.googlecode.objectify.annotation.Subclass;
 
 /**
  * Simple class to extend the entity db queue, this allows us
  * to store this in a separate database table.
  */
-@Entity(name="QueueListItem")
+@Subclass(index=true, name="QueueListItem")
 public class QueueListItemObject extends MediaListItem { }

--- a/src/main/java/com/google/sps/model/queue/ViewedListItemObject.java
+++ b/src/main/java/com/google/sps/model/queue/ViewedListItemObject.java
@@ -1,10 +1,11 @@
 package com.google.sps.model.queue;
 
 import com.googlecode.objectify.annotation.Entity;
+import com.googlecode.objectify.annotation.Subclass;
 
 /**
  * Simple class to extend the entity db queue, this allows us
  * to store this in a separate database table.
  */
-@Entity(name="ViewedListItem")
+@Subclass(index=true, name="ViewedListItem")
 public class ViewedListItemObject extends MediaListItem { }

--- a/src/main/java/com/google/sps/model/review/ReviewObject.java
+++ b/src/main/java/com/google/sps/model/review/ReviewObject.java
@@ -76,13 +76,6 @@ public class ReviewObject extends Activity {
     @Index
     private int rating;
 
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public long getTimestamp() {
         return timestamp;
@@ -93,11 +86,11 @@ public class ReviewObject extends Activity {
     }
 
     public String getAuthorId() {
-        return authorId;
+        return userId;
     }
 
     public void setAuthorId(String authorId) {
-        this.authorId = authorId;
+        this.userId = authorId;
     }
 
     public String getAuthorName() {

--- a/src/main/java/com/google/sps/model/review/ReviewObject.java
+++ b/src/main/java/com/google/sps/model/review/ReviewObject.java
@@ -3,7 +3,6 @@ package com.google.sps.model.review;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.sps.model.activity.Activity;
 import com.google.sps.model.user.UserObject;
-import com.googlecode.objectify.annotation.Entity;
 import com.googlecode.objectify.annotation.Index;
 import com.googlecode.objectify.annotation.Subclass;
 
@@ -24,7 +23,7 @@ public class ReviewObject extends Activity {
         Timestamp currentTime = new Timestamp(System.currentTimeMillis());
         this.timestamp = currentTime.getTime();
 
-        this.authorId = userObject.getId();
+        this.userId = userObject.getId();
         this.authorName = userObject.getUsername();
 
         this.contentType = contentType;
@@ -43,7 +42,7 @@ public class ReviewObject extends Activity {
 
     @JsonProperty
     @Index
-    private String authorId;
+    private String userId;
 
     @JsonProperty
     @Index

--- a/src/main/java/com/google/sps/model/review/ReviewObject.java
+++ b/src/main/java/com/google/sps/model/review/ReviewObject.java
@@ -1,23 +1,16 @@
 package com.google.sps.model.review;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.api.services.books.model.Volume;
-import com.google.sps.servlets.book.BookDetailsServlet;
-import com.google.sps.servlets.movie.MovieDetailsServlet;
+import com.google.sps.model.activity.Activity;
 import com.google.sps.model.user.UserObject;
 import com.googlecode.objectify.annotation.Entity;
-import com.googlecode.objectify.annotation.Id;
 import com.googlecode.objectify.annotation.Index;
-import info.movito.themoviedbapi.model.MovieDb;
+import com.googlecode.objectify.annotation.Subclass;
 
-import java.io.IOException;
-import java.security.GeneralSecurityException;
 import java.sql.Timestamp;
 
-import static com.google.sps.util.Utils.parseInt;
-
-@Entity
-public class ReviewObject {
+@Subclass(index=true, name="ReviewObject")
+public class ReviewObject extends Activity {
 
     public ReviewObject() {
         Timestamp currentTime = new Timestamp(System.currentTimeMillis());
@@ -43,11 +36,6 @@ public class ReviewObject {
         this.reviewBody = reviewBody;
         this.rating = rating;
     }
-
-    @Id
-    @JsonProperty
-    @Index
-    private Long id;
 
     @JsonProperty
     @Index

--- a/src/main/java/com/google/sps/servlets/activity/RecentActivityServlet.java
+++ b/src/main/java/com/google/sps/servlets/activity/RecentActivityServlet.java
@@ -27,10 +27,18 @@ import static com.googlecode.objectify.ObjectifyService.ofy;
 @WebServlet("/activity/followers")
 public class RecentActivityServlet extends HttpServlet {
 
-    private final ObjectMapper mapper = new ObjectMapper();
     private final Gson gson = new Gson();
     private final int ACTIVITY_LIMIT = 10;
 
+    /**
+     * doGet() is an endpoint that takes in two params, a userId to check, and an offset (how many pages the user is in)
+     * The doGet() will return a 400 error if the user is missing any query params, if not, then it'll return an empty
+     * arraylist if there is no activity, or an arraylist of activity objects if there is activity
+     * @param request: request coming in from user with userId and offset
+     * @param response: an arraylist of Activity objects
+     * @throws ServletException
+     * @throws IOException
+     */
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         int offset;
@@ -44,7 +52,7 @@ public class RecentActivityServlet extends HttpServlet {
         try {
             offset = Utils.parseInt(request.getParameter("offset"));
         } catch (NullPointerException e){
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+            HttpUtils.setInvalidGetResponse(response);
             return;
         }
 
@@ -56,15 +64,29 @@ public class RecentActivityServlet extends HttpServlet {
         response.getWriter().println(gson.toJsonTree(reviews));
     }
 
+    /**
+     * Helper function to get a users following list, used to feed into objectify
+     * @param userId: the user id to get followers from
+     * @return: an arraylist of following of a userID
+     */
     private List<String> getFollowingList(String userId) {
         List<FollowItem> userObjects = ofy().load().type(FollowItem.class).filter("userId", userId).list();
         return userObjects.stream().
-                map(FollowItem::getUserId).collect(Collectors.toList());
+                map(FollowItem::getTargetId).collect(Collectors.toList());
     }
 
+    /**
+     * A function to get a following activity (could be list activity or reviews)
+     * @param following: an arraylist of following userIds
+     * @param offset: number to offset by, goes in 10s
+     * @return: an arraylist of activity given the list of following
+     */
     private List<Activity> getActivity(List<String> following, int offset) {
+        if(following.size() == 0) {
+            new ArrayList<Activity>();
+        }
         return ofy().load().type(Activity.class)
-                .filter("userId", following)
+                .filter("userId IN", following)
                 .order("-timestamp")
                 .limit(ACTIVITY_LIMIT)
                 .offset(offset)

--- a/src/main/java/com/google/sps/servlets/activity/RecentActivityServlet.java
+++ b/src/main/java/com/google/sps/servlets/activity/RecentActivityServlet.java
@@ -19,11 +19,6 @@ import java.util.stream.Collectors;
 
 import static com.googlecode.objectify.ObjectifyService.ofy;
 
-/**
- * @author chris
- * date: 7/21/2020
- */
-
 @WebServlet("/activity/followers")
 public class RecentActivityServlet extends HttpServlet {
 

--- a/src/main/java/com/google/sps/servlets/activity/RecentActivityServlet.java
+++ b/src/main/java/com/google/sps/servlets/activity/RecentActivityServlet.java
@@ -1,0 +1,69 @@
+package com.google.sps.servlets.activity;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.sps.model.follow.FollowItem;
+import com.google.sps.model.queue.QueueListItemObject;
+import com.google.sps.model.queue.ViewedListItemObject;
+import com.google.sps.model.review.ReviewObject;
+import com.google.sps.model.user.UserObject;
+import com.google.sps.util.HttpUtils;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.googlecode.objectify.ObjectifyService.ofy;
+
+/**
+ * @author chris
+ * date: 7/21/2020
+ */
+
+@WebServlet("/activity/followers")
+public class RecentActivityServlet extends HttpServlet {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        List<Object> results = new ArrayList<>();
+
+        String userId = request.getParameter("userId");
+        if (userId == null) {
+            HttpUtils.setInvalidGetResponse(response);
+            return;
+        }
+        List<String> following = getFollowingList(userId);
+
+        List<ReviewObject> reviews = getFollowingReviews(following);
+        List<ViewedListItemObject> viewed = getFollowingViewed(following);
+        List<QueueListItemObject> queue = getFollowingQueue(following);
+    }
+
+    private List<String> getFollowingList(String userId) {
+        List<FollowItem> userObjects = ofy().load().type(FollowItem.class).filter("userId", userId).list();
+        return userObjects.stream().
+                map(FollowItem::getUserId).collect(Collectors.toList());
+    }
+
+    private List<ReviewObject> getFollowingReviews(List<String> following) {
+        return ofy().load().type(ReviewObject.class).filter("userId", following).list();
+    }
+
+    private List<QueueListItemObject> getFollowingQueue(List<String> following) {
+        return ofy().load().type(QueueListItemObject.class).filter("userId", following).list();
+    }
+
+    private List<ViewedListItemObject> getFollowingViewed(List <String> following) {
+        return ofy().load().type(ViewedListItemObject.class).filter("userId", following).list();
+    }
+}

--- a/src/main/java/com/google/sps/servlets/activity/RecentActivityServlet.java
+++ b/src/main/java/com/google/sps/servlets/activity/RecentActivityServlet.java
@@ -33,7 +33,6 @@ public class RecentActivityServlet extends HttpServlet {
 
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        List<Object> results = new ArrayList<>();
         int offset;
 
         String userId = request.getParameter("userId");
@@ -66,7 +65,7 @@ public class RecentActivityServlet extends HttpServlet {
     private List<Activity> getActivity(List<String> following, int offset) {
         return ofy().load().type(Activity.class)
                 .filter("userId", following)
-                .order("timestamp")
+                .order("-timestamp")
                 .limit(ACTIVITY_LIMIT)
                 .offset(offset)
                 .list();

--- a/src/main/java/com/google/sps/servlets/activity/RecentActivityServlet.java
+++ b/src/main/java/com/google/sps/servlets/activity/RecentActivityServlet.java
@@ -83,7 +83,7 @@ public class RecentActivityServlet extends HttpServlet {
      */
     private List<Activity> getActivity(List<String> following, int offset) {
         if(following.size() == 0) {
-            new ArrayList<Activity>();
+            return new ArrayList<Activity>();
         }
         return ofy().load().type(Activity.class)
                 .filter("userId IN", following)

--- a/src/main/java/com/google/sps/servlets/review/ReviewServlet.java
+++ b/src/main/java/com/google/sps/servlets/review/ReviewServlet.java
@@ -256,39 +256,4 @@ public class ReviewServlet extends HttpServlet {
 
         return true;
     }
-
-    private String[] getTitleAndArtUrl(String contentType, String contentId) throws Exception {
-        String title, artUrl;
-        switch (contentType) {
-            case ContentType.BOOK:
-                Volume volume = new BookDetailsServlet().getDetails(contentId);
-                title = volume.getVolumeInfo().getTitle();
-                artUrl = volume.getVolumeInfo().getImageLinks().getThumbnail();
-                break;
-            case ContentType.MOVIE:
-                Integer intId = parseInt(contentId);
-                if (intId == null) {
-                    throw new IllegalArgumentException();
-                }
-                MovieDb movie = new MovieDetailsServlet().getDetails(intId);
-                title = movie.getTitle();
-                artUrl = movie.getPosterPath();
-                break;
-            default:
-                throw new IllegalArgumentException();
-        }
-        return new String[]{title, artUrl};
-    }
-
-    private ReviewObject createAndSaveReview(UserObject userObject,
-                                             String contentType, String contentId,
-                                             String reviewTitle, String reviewBody, int rating) throws Exception {
-        String[] titleAndArtUrl = getTitleAndArtUrl(contentType, contentId);
-        ReviewObject reviewObject = new ReviewObject(userObject,
-                contentType, contentId,
-                titleAndArtUrl[0], titleAndArtUrl[1],
-                reviewTitle, reviewBody, rating);
-        ofy().save().entity(reviewObject).now();
-        return reviewObject;
-    }
 }

--- a/src/main/java/com/google/sps/servlets/review/ReviewServlet.java
+++ b/src/main/java/com/google/sps/servlets/review/ReviewServlet.java
@@ -149,9 +149,9 @@ public class ReviewServlet extends HttpServlet {
         tryDelete(user.getUserId(), contentType, contentId, response);
     }
 
-    private void tryDelete(String authorId, String contentType, String contentId, HttpServletResponse response)
+    private void tryDelete(String userId, String contentType, String contentId, HttpServletResponse response)
             throws IOException {
-        QueryKeys<ReviewObject> keys =  getMatchingReviews(authorId, contentType, contentId);
+        QueryKeys<ReviewObject> keys =  getMatchingReviews(userId, contentType, contentId);
 
         if(Iterables.size(keys) == 0) {
             response.sendError(HttpServletResponse.SC_NOT_FOUND);
@@ -162,9 +162,9 @@ public class ReviewServlet extends HttpServlet {
         }
     }
 
-    private QueryKeys<ReviewObject> getMatchingReviews(String authorId, String contentType, String contentId) {
+    private QueryKeys<ReviewObject> getMatchingReviews(String userId, String contentType, String contentId) {
         return ofy().load().type(ReviewObject.class)
-                .filter("authorId", authorId)
+                .filter("userId", userId)
                 .filter("contentType", contentType)
                 .filter("contentId", contentId).keys();
     }
@@ -178,7 +178,7 @@ public class ReviewServlet extends HttpServlet {
         }
         else {
             List<ReviewObject> reviews = ofy().load().type(ReviewObject.class)
-                    .filter("authorId", userId)
+                    .filter("userId", userId)
                     .list();
             response.getWriter().println(gson.toJson(reviews));
         }

--- a/src/main/java/com/google/sps/servlets/review/ReviewServlet.java
+++ b/src/main/java/com/google/sps/servlets/review/ReviewServlet.java
@@ -245,7 +245,7 @@ public class ReviewServlet extends HttpServlet {
         String[] titleAndArtUrl = getTitleAndArtUrl(contentType, contentId);
         ReviewObject reviewObject = new ReviewObject(userObject,
                 contentType, contentId,
-                titleAndArtUrl[0], titleAndArtUrl[0],
+                titleAndArtUrl[0], titleAndArtUrl[1],
                 reviewTitle, reviewBody, rating);
         ofy().save().entity(reviewObject).now();
         return reviewObject;

--- a/src/test/java/com/google/sps/servlets/activity/RecentActivityServletTest.java
+++ b/src/test/java/com/google/sps/servlets/activity/RecentActivityServletTest.java
@@ -70,11 +70,6 @@ public class RecentActivityServletTest {
     }
 
     @Test
-    public void getEmptyList() {
-
-    }
-
-    @Test
     public void errorRequest() throws ServletException, IOException {
         addFollowers();
         HttpServletRequest request = mock(HttpServletRequest.class);

--- a/src/test/java/com/google/sps/servlets/activity/RecentActivityServletTest.java
+++ b/src/test/java/com/google/sps/servlets/activity/RecentActivityServletTest.java
@@ -1,0 +1,152 @@
+package com.google.sps.servlets.activity;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import com.google.appengine.tools.development.testing.LocalUserServiceTestConfig;
+import com.google.sps.ContextListener;
+import com.google.sps.model.activity.Activity;
+import com.google.sps.model.follow.FollowItem;
+import com.google.sps.model.queue.QueueListItemObject;
+import com.google.sps.model.queue.ViewedListItemObject;
+import com.google.sps.model.review.ReviewObject;
+import com.google.sps.model.user.UserObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.googlecode.objectify.ObjectifyService.ofy;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class RecentActivityServletTest {
+
+    private ObjectMapper mapper = new ObjectMapper();
+    private HttpServletResponse response;
+    private StringWriter stringWriter;
+    private PrintWriter writer;
+    private LocalServiceTestHelper helper;
+
+    @Before
+    public void before() throws IOException{
+        new ContextListener().initDbObjects();
+        Map<String, Object> attr = new HashMap<>();
+        attr.put("com.google.appengine.api.users.UserService.user_id_key", "9876");
+
+        helper =
+                new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig(),
+                        new LocalUserServiceTestConfig())
+                        .setEnvAttributes(attr)
+                        .setEnvIsAdmin(true)
+                        .setEnvIsLoggedIn(true)
+                        .setEnvEmail("test@email.com")
+                        .setEnvAuthDomain("mediaphile.com");
+        helper.setUp();
+
+        response = mock(HttpServletResponse.class);
+
+        stringWriter = new StringWriter();
+        writer = new PrintWriter(stringWriter);
+        when(response.getWriter()).thenReturn(writer);
+
+    }
+
+    @After
+    public void tearDown() {
+        helper.tearDown();
+        ofy().clear();
+    }
+
+    @Test
+    public void getEmptyList() {
+
+    }
+
+    @Test
+    public void errorRequest() throws ServletException, IOException {
+        addFollowers();
+        HttpServletRequest request = mock(HttpServletRequest.class);
+
+        when(request.getParameter("userId")).thenReturn("9876");
+
+        new RecentActivityServlet().doGet(request, response);
+
+        verify(response, times(1)).setStatus(400);
+    }
+
+    @Test
+    public void getFilledList() throws ServletException, IOException {
+        addFollowers();
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getParameter("userId")).thenReturn("0123");
+        when(request.getParameter("offset")).thenReturn("0");
+
+        new RecentActivityServlet().doGet(request, response);
+
+        writer.flush();
+
+        List<QueueListItemObject> activityList = mapper.readValue(stringWriter.toString(), new TypeReference<List<QueueListItemObject>>(){});
+
+        assertEquals( 1, activityList.size());
+    }
+
+    @Test
+    public void emptyList() throws ServletException, IOException {
+        addFollowers();
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getParameter("userId")).thenReturn("9876");
+        when(request.getParameter("offset")).thenReturn("0");
+
+        new RecentActivityServlet().doGet(request, response);
+
+        writer.flush();
+
+        List<QueueListItemObject> activityList = mapper.readValue(stringWriter.toString(), new TypeReference<List<QueueListItemObject>>(){});
+
+        assertEquals( 0, activityList.size());
+    }
+    private void addFollowers() {
+        //bravo follows alpha
+        FollowItem followers = new FollowItem();
+        followers.setId(1234L);
+        followers.setUserId("0123");
+        followers.setTargetId("9876");
+
+        ofy().save().entity(followers).now();
+
+        //alpha follows charlie
+        FollowItem following = new FollowItem();
+        following.setId(4321L);
+        following.setUserId("9876");
+        following.setTargetId("3210");
+
+        ofy().save().entity(following).now();
+
+        UserObject alpha = new UserObject("9876", "alpha", "alpha@example.com", "");
+        ofy().save().entity(alpha).now();
+
+        UserObject bravo = new UserObject("0123", "bravo", "bravo@example.com", "");
+        ofy().save().entity(bravo).now();
+
+        UserObject charlie = new UserObject("3210", "charlie", "charlie@example.com", "");
+        ofy().save().entity(charlie).now();
+
+        QueueListItemObject queue = new QueueListItemObject();
+        following.setId(4321L);
+        queue.setArtUrl("http://fdsa");
+        queue.setUserId("9876");
+        ofy().save().entity(queue).now();
+    }
+}

--- a/src/test/java/com/google/sps/servlets/review/ReviewServletTest.java
+++ b/src/test/java/com/google/sps/servlets/review/ReviewServletTest.java
@@ -264,7 +264,7 @@ public class ReviewServletTest extends Mockito {
         writer.flush();
 
         List<ReviewObject> reviews = ofy().load().type(ReviewObject.class)
-                .filter("authorId", DUMMY_USER_ID)
+                .filter("userId", DUMMY_USER_ID)
                 .list();
         assertNotNull(reviews);
         assertFalse(reviews.isEmpty());
@@ -292,7 +292,7 @@ public class ReviewServletTest extends Mockito {
         writer.flush();
 
         List<ReviewObject> reviews = ofy().load().type(ReviewObject.class)
-                .filter("authorId", DUMMY_USER_ID)
+                .filter("userId", DUMMY_USER_ID)
                 .list();
         assertNotNull(reviews);
         assertFalse(reviews.isEmpty());
@@ -421,7 +421,7 @@ public class ReviewServletTest extends Mockito {
                 DUMMY_REVIEW_TITLE, DUMMY_REVIEW_BODY, Integer.parseInt(GOOD_DUMMY_RATING));
         ofy().save().entity(reviewObject).now();
         List<ReviewObject> reviews = ofy().load().type(ReviewObject.class)
-                .filter("authorId", DUMMY_USER_ID)
+                .filter("userId", DUMMY_USER_ID)
                 .list();
         assertFalse(reviews.isEmpty());
 
@@ -429,7 +429,7 @@ public class ReviewServletTest extends Mockito {
         writer.flush();
 
         reviews = ofy().load().type(ReviewObject.class)
-                .filter("authorId", DUMMY_USER_ID)
+                .filter("userId", DUMMY_USER_ID)
                 .list();
         assertTrue(reviews.isEmpty());
     }
@@ -449,7 +449,7 @@ public class ReviewServletTest extends Mockito {
                 DUMMY_REVIEW_TITLE, DUMMY_REVIEW_BODY, Integer.parseInt(GOOD_DUMMY_RATING));
         ofy().save().entity(reviewObject).now();
         List<ReviewObject> reviews = ofy().load().type(ReviewObject.class)
-                .filter("authorId", DUMMY_USER_ID)
+                .filter("userId", DUMMY_USER_ID)
                 .list();
         assertFalse(reviews.isEmpty());
 
@@ -458,7 +458,7 @@ public class ReviewServletTest extends Mockito {
         writer.flush();
 
         reviews = ofy().load().type(ReviewObject.class)
-                .filter("authorId", DUMMY_USER_ID)
+                .filter("userId", DUMMY_USER_ID)
                 .list();
         assertTrue(reviews.isEmpty());
     }


### PR DESCRIPTION
## Objectify
 - Bumps version up from 4.x -> 5.0. This allows for a needed annotation to have sub classes within POJOs

## Home Entity
 - Refactors to do a tile view instead of list view, looks a lot better imo

## Search Entity
 - Refactors to do a tile view instead of list view, looks a lot better imo

## Recent Activity
 - Implements a "recent activity" section. This endpoint takes in a userId and an offset, and will return a list of "Activity" objects. If there is no activity, it will return an empty list
 - 400 errors are thrown if the query params are missing

## Bugs?
 - Currently, with the way we save entities, there is no way to access username. for right now for any activity that is a "add to queue", it'll show "Someone you follow did XXXXXX", instead of showing username. This will be fixed in a later PR.