### PR TITLE
Add redirect to review button after user login

### DIFF
--- a/mediaphile/src/app/info.service.ts
+++ b/mediaphile/src/app/info.service.ts
@@ -67,8 +67,11 @@ export class InfoService {
     })
   }
 
-  public login() {
-    return this.http.get<LoginStatusStruct>(this.loginStatus)
+  public login(redirect?: string) {
+    let params = (redirect) ? {redirect: redirect} : {};
+    return this.http.get<LoginStatusStruct>(this.loginStatus, {
+      params: params
+    })
   }
 
   public logout() {
@@ -78,15 +81,6 @@ export class InfoService {
   }
 
   public getUser(userId: string) {
-    // TODO: Remove placeholder
-    if ((['123', '234', '345'].indexOf(userId) >= 0)) {
-      return of({
-        id: userId,
-        email: "other@example.com",
-        profilePicUrl: "https://3.bp.blogspot.com/-qDc5kIFIhb8/UoJEpGN9DmI/AAAAAAABl1s/BfP6FcBY1R8/s320/BlueHead.jpg",
-        username: "other",
-      });
-    }
     return this.http.get(this.userEndpoint, {
       params: {
         "id": userId,

--- a/mediaphile/src/app/pages/book-details/book-details.component.html
+++ b/mediaphile/src/app/pages/book-details/book-details.component.html
@@ -46,9 +46,9 @@
   </main>
 </div>
 
-<div #reviews *ngIf="bookData != undefined" class = "container reviews">
+<div #reviews class = "container reviews">
   <h2>Reviews: </h2>
-  <app-review [type]="'book'" [id]="bookId"  [title]="bookData['volumeInfo']['title']" [artUrl]="getEntityPosterUrl()"></app-review>
+  <app-review *ngIf="bookData != undefined" [type]="'book'" [id]="bookId"  [title]="bookData['volumeInfo']['title']" [artUrl]="getEntityPosterUrl()"></app-review>
 </div>
 
 <ng-template #loading>

--- a/mediaphile/src/app/pages/book-details/book-details.component.html
+++ b/mediaphile/src/app/pages/book-details/book-details.component.html
@@ -48,7 +48,7 @@
 
 <div #reviews class = "container reviews">
   <h2>Reviews: </h2>
-  <app-review *ngIf="bookData != undefined" [type]="'book'" [id]="bookId"  [title]="bookData['volumeInfo']['title']" [artUrl]="getEntityPosterUrl()"></app-review>
+  <app-review *ngIf="this.entity | async" [type]="'book'" [id]="bookId"  [title]="getEntityTitle()" [artUrl]="getEntityPosterUrl()"></app-review>
 </div>
 
 <ng-template #loading>

--- a/mediaphile/src/app/pages/book-details/book-details.component.ts
+++ b/mediaphile/src/app/pages/book-details/book-details.component.ts
@@ -69,12 +69,16 @@ export class BookDetailsComponent implements OnInit {
     }
   }
 
+  public getEntityTitle() : string {
+    return (this.bookData) ? this.bookData['volumeInfo']['title'] : "";
+  }
+
   public getEntityImageUrl() : string {
     return "assets/placeholder.jpeg"
   }
 
   public getEntityPosterUrl(): string {
-    if("imageLinks" in this.bookData["volumeInfo"]) {
+    if(this.bookData && "imageLinks" in this.bookData["volumeInfo"]) {
       return this.bookData["volumeInfo"]["imageLinks"]["thumbnail"]
     }
     return "assets/poster-placeholder.png"

--- a/mediaphile/src/app/pages/helper/review-submit/review-submit.component.ts
+++ b/mediaphile/src/app/pages/helper/review-submit/review-submit.component.ts
@@ -37,9 +37,11 @@ export class ReviewSubmitComponent implements OnInit {
 
   ngOnInit(): void {
     this.loginStatus.sharedAccountId.subscribe(userId => {
-      this.infoSvc.getUser(userId).subscribe(userData => {
-        this.currentUser = userData;
-      });
+      if (userId != "") {
+        this.infoSvc.getUser(userId).subscribe(userData => {
+          this.currentUser = userData;
+        });
+      }
     });
   }
 

--- a/mediaphile/src/app/pages/helper/review/review.component.html
+++ b/mediaphile/src/app/pages/helper/review/review.component.html
@@ -1,5 +1,8 @@
 <div class = "review-container" *ngIf="reviews | async as reviews ; else loading">
-  <button  *ngIf = "loginStatus.sharedStatus | async" class="btn btn-primary review" data-toggle="modal" data-target="#exampleModal">Write a Review</button>
+  <button  *ngIf = "(loginStatus.sharedStatus | async); else login" class="btn btn-primary review" data-toggle="modal" data-target="#exampleModal">Write a Review</button>
+  <ng-template #login>
+    <button class="btn btn-primary review" (click)="loginWithRedirect()">Write a Review</button>
+  </ng-template>
   <div *ngFor="let review of reviews">
     <app-review-entity [review]="review"></app-review-entity>
   </div>

--- a/mediaphile/src/app/pages/helper/review/review.component.ts
+++ b/mediaphile/src/app/pages/helper/review/review.component.ts
@@ -4,6 +4,7 @@ import {LoginStatus} from "../../../auth/login.status";
 import {Observable} from "rxjs";
 import {Review} from "../../../struct/Review";
 import {faEye} from "@fortawesome/free-solid-svg-icons";
+import {Router} from "@angular/router";
 
 @Component({
   selector: 'app-review',
@@ -28,10 +29,14 @@ export class ReviewComponent implements OnInit {
 
   reviews: Observable<Review[]>
 
-  constructor(private infoSvc: InfoService, public loginStatus: LoginStatus) { }
+  constructor(private infoSvc: InfoService, private router: Router, public loginStatus: LoginStatus) { }
 
   ngOnInit(): void {
-    this.reviews = this.infoSvc.getReviewsForMedia(this.id, this.type)
+    this.reviews = this.infoSvc.getReviewsForMedia(this.id, this.type);
+  }
+
+  loginWithRedirect() {
+    this.router.navigate(["/login"], {queryParams: {redirect: this.router.url}});
   }
 
 }

--- a/mediaphile/src/app/pages/login/login.component.ts
+++ b/mediaphile/src/app/pages/login/login.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import {InfoService} from "../../info.service";
+import {ActivatedRoute} from "@angular/router";
 
 @Component({
   selector: 'app-login',
@@ -8,14 +9,20 @@ import {InfoService} from "../../info.service";
 })
 export class LoginComponent implements OnInit {
 
-  constructor(private infoSvc: InfoService) { }
+  private redirect: string;
+
+  constructor(private infoSvc: InfoService, private route: ActivatedRoute) { }
 
   ngOnInit(): void {
+    this.route.queryParams.subscribe(params => {
+      if (params['redirect']) this.redirect = params['redirect'];
+    });
   }
 
   public login() {
+    let redirect_query = (this.redirect) ? ("?redirect=" + this.redirect) : "";
     this.infoSvc.login().subscribe(loginStatus => {
-      window.location.href = loginStatus["url"];
+      window.location.href = loginStatus["url"] + redirect_query;
     })
   }
 }

--- a/mediaphile/src/app/pages/movie-details/movie-details.component.html
+++ b/mediaphile/src/app/pages/movie-details/movie-details.component.html
@@ -43,9 +43,9 @@
   </main>
 </div>
 
-<div *ngIf="movieData != undefined" #reviews class="container reviews">
+<div #reviews class="container reviews">
   <h2>Reviews: </h2>
-  <app-review [type]="'movie'" [id]="movieId" [title]="entity['title']" [artUrl]="getEntityPosterUrl()"></app-review>
+  <app-review *ngIf="movieData != undefined"  [type]="'movie'" [id]="movieId" [title]="entity['title']" [artUrl]="getEntityPosterUrl()"></app-review>
 </div>
 
 <ng-template #loading>

--- a/mediaphile/src/app/pages/movie-details/movie-details.component.html
+++ b/mediaphile/src/app/pages/movie-details/movie-details.component.html
@@ -45,7 +45,7 @@
 
 <div #reviews class="container reviews">
   <h2>Reviews: </h2>
-  <app-review *ngIf="movieData != undefined"  [type]="'movie'" [id]="movieId" [title]="entity['title']" [artUrl]="getEntityPosterUrl()"></app-review>
+  <app-review *ngIf="this.entity | async" [type]="'movie'" [id]="movieId" [title]="entity['title']" [artUrl]="getEntityPosterUrl()"></app-review>
 </div>
 
 <ng-template #loading>

--- a/mediaphile/src/app/pages/movie-details/movie-details.component.ts
+++ b/mediaphile/src/app/pages/movie-details/movie-details.component.ts
@@ -70,14 +70,14 @@ export class MovieDetailsComponent implements OnInit {
   }
 
   public getEntityImageUrl() : string {
-    if(this.movieData["backdropPath"]) {
+    if(this.movieData && this.movieData["backdropPath"]) {
       return "https://image.tmdb.org/t/p/original" + this.movieData['backdropPath']
     }
     return "assets/placeholder.jpeg"
   }
 
   public getEntityPosterUrl(): string {
-    if(this.movieData["posterPath"]) {
+    if(this.movieData && this.movieData["posterPath"]) {
       return "https://image.tmdb.org/t/p/w500" + this.movieData['posterPath']
     }
     return "assets/poster-placeholder.png"

--- a/src/main/java/com/google/sps/servlets/user/LoginRegistrationServlet.java
+++ b/src/main/java/com/google/sps/servlets/user/LoginRegistrationServlet.java
@@ -48,13 +48,15 @@ public class LoginRegistrationServlet extends HttpServlet {
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
         response.setContentType("application/json; charset=utf-8");
 
+        String redirect = request.getParameter("redirect");
+        boolean has_redirect = (redirect != null) && !(redirect.isEmpty());
+
         String logout = request.getParameter("logout");
         if (logout != null && logout.equals("1")) {
             eraseLoginCookies(request, response);
-            response.sendRedirect("/");
+            response.sendRedirect((has_redirect) ? redirect : "/");
             return;
         }
-
 
         UserService userService = UserServiceFactory.getUserService();
         User user = userService.getCurrentUser();
@@ -65,6 +67,6 @@ public class LoginRegistrationServlet extends HttpServlet {
 
         storeUserIfNotFound(user.getUserId(), user.getEmail().split("@")[0], user.getEmail(), "");
 
-        response.sendRedirect("/home");
+        response.sendRedirect((has_redirect) ? redirect : "/home");
     }
 }

--- a/src/main/java/com/google/sps/servlets/user/LoginStatusServlet.java
+++ b/src/main/java/com/google/sps/servlets/user/LoginStatusServlet.java
@@ -34,11 +34,15 @@ public class LoginStatusServlet extends HttpServlet {
         } else {
             redirect = redirect.trim();
         }
-        String redirect_query = (redirect.isEmpty()) ? "" : "?redirect=" + redirect;
 
         UserService userService = UserServiceFactory.getUserService();
 
         boolean loggedIn = userService.isUserLoggedIn();
+        String redirect_query = "";
+        if (!redirect.isEmpty()) {
+            redirect_query = ((loggedIn) ? "&" : "?") + "redirect=" + redirect;
+        }
+
         String url = (loggedIn)
                 ? "/login/register?logout=1" + redirect_query
                 : userService.createLoginURL("/login/register" + redirect_query);

--- a/src/main/java/com/google/sps/servlets/user/LoginStatusServlet.java
+++ b/src/main/java/com/google/sps/servlets/user/LoginStatusServlet.java
@@ -28,12 +28,20 @@ public class LoginStatusServlet extends HttpServlet {
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
         response.setContentType("application/json; charset=utf-8");
 
+        String redirect = request.getParameter("redirect");
+        if (redirect == null) {
+            redirect = "";
+        } else {
+            redirect = redirect.trim();
+        }
+        String redirect_query = (redirect.isEmpty()) ? "" : "?redirect=" + redirect;
+
         UserService userService = UserServiceFactory.getUserService();
 
         boolean loggedIn = userService.isUserLoggedIn();
         String url = (loggedIn)
-                ? "/login/register?logout=1"
-                : userService.createLoginURL("/login/register");
+                ? "/login/register?logout=1" + redirect_query
+                : userService.createLoginURL("/login/register" + redirect_query);
         User user = userService.getCurrentUser();
         String id = (user != null) ? user.getUserId() : "";
 


### PR DESCRIPTION
Based on @kirantumkur's comment during Friday's demo.

## Backend
- Added an optional `redirect` parameter to both `/login/status` and `/login/register`
    - If given to `/login/status`, then the returned login/logout URL will include instructions to redirect
        - Logout: Redirects to `/login/register?logout=1&redirect=...`
        - Login: Redirects to the URL generated by userService, including instructions to redirect to `/login/register?redirect=..."
    - `/login/register` accepts `?redirect` and simply redirects on success
        - Defaults to "/" on logout and "/home" on login

## Frontend
- The "Add a review" button now displays whether or not the user is logged in
    - This makes "Be the first to add a review" actionable
    - When the user is not logged in, this button sends them to the login page and ultimately redirects them back to the movie page
- Login page now accepts an optional query parameter `redirect`
    - Sent to the login endpoint