### PR TITLE
Fix formatting of username, follow button, and mobile layout on profile

### DIFF
--- a/mediaphile/src/app/pages/user-profile/user-profile.component.html
+++ b/mediaphile/src/app/pages/user-profile/user-profile.component.html
@@ -7,7 +7,7 @@
           {{getProfilePicChar()}}
         </div>
       </div>
-      <h1 class="col-md-1 align-self-center">{{entity['username']}}</h1>
+      <h1 id="username" class="align-self-center">{{entity['username']}}</h1>
       <button *ngIf="!isSelf" (click)="toggleFollow()" id="follow-button" class="align-self-center">
         {{(followed) ? "Unfollow" : "Follow"}}
       </button>

--- a/mediaphile/src/app/pages/user-profile/user-profile.component.scss
+++ b/mediaphile/src/app/pages/user-profile/user-profile.component.scss
@@ -12,17 +12,12 @@ span {
   display: inline;
 }
 
-@media only screen and (max-width: 768px) {
-  span {
-    display:none;
-  }
-}
-
 #profile-pic-container {
   background-color: rgb(17, 164, 209);
   border-radius: 5px;
   width: 125px;
   height: 125px;
+  margin-right: 20px;
 }
 
 #profile-pic-char {
@@ -33,7 +28,7 @@ span {
 
 #follow-button {
   padding: 10px;
-  margin-left: 40px;
+  margin-left: 15px;
   background-color:$base-color;
   border-radius: 23px;
   color: white;
@@ -43,4 +38,27 @@ span {
 }
 #follow-button:hover {
   background-color: #1763a9;
+}
+
+.nav-tabs {
+  width:100%;
+}
+.nav-tabs .nav-link {
+  width: 25%;
+}
+
+@media only screen and (max-width: 768px) {
+  span {
+    display: none;
+  }
+
+  #username {
+    margin: 6px 0;
+    font-size: 2.0rem;
+    overflow: hidden;
+  }
+
+  #follow-button {
+    margin-left: 0;
+  }
 }

--- a/mediaphile/src/app/pages/user-profile/user-profile.component.scss
+++ b/mediaphile/src/app/pages/user-profile/user-profile.component.scss
@@ -40,13 +40,6 @@ span {
   background-color: #1763a9;
 }
 
-.nav-tabs {
-  width:100%;
-}
-.nav-tabs .nav-link {
-  width: 25%;
-}
-
 @media only screen and (max-width: 768px) {
   span {
     display: none;
@@ -60,5 +53,12 @@ span {
 
   #follow-button {
     margin-left: 0;
+  }
+
+  .nav-tabs {
+    width:100%;
+  }
+  .nav-tabs .nav-link {
+    width: 25%;
   }
 }


### PR DESCRIPTION
**This PR fixes several minor formatting problems on the user profile page.**
- The username is now moved to the left by a `margin-right` on the profile pic, rather than a `margin-left` on itself
- The follow button is now positioned relative to the username
    - If there is horizontal room, it will display to the right of the username
    - If there is not room (i.e. phone screen), it will display below the username
- The header elements will now stack vertically on small screens
- Tabs will now stretch horizontally on mobile screens

# Screenshots
![image](https://user-images.githubusercontent.com/30727195/88582051-1482ce80-d01c-11ea-98a9-82ec56af8d43.png)
![image](https://user-images.githubusercontent.com/30727195/88582368-9c68d880-d01c-11ea-8b5b-3be11a6b13ef.png)
