### PR TITLE
Recommendations servlet for books and movies

### DIFF
--- a/mediaphile/src/app/pages/search/results/results.component.ts
+++ b/mediaphile/src/app/pages/search/results/results.component.ts
@@ -70,8 +70,10 @@ export class ResultsComponent implements OnInit {
     this.infoSvc.searchBooks(query, this.pageNumber).subscribe(data => {
       if(this.hasReceivedResults()) {
         this.arrayResults.push.apply(this.arrayResults, data["results"])
+        this.total_results = data["total_results"];
       } else {
         this.arrayResults = data["results"];
+        this.total_results = data["total_results"];
         if(this.arrayResults == null) {
           this.hasResults = false;
           this.arrayResults = [];

--- a/src/main/java/com/google/sps/model/results/ResultsObject.java
+++ b/src/main/java/com/google/sps/model/results/ResultsObject.java
@@ -1,0 +1,26 @@
+package com.google.sps.model.results;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class ResultsObject<T> {
+    @JsonProperty
+    private final List<T> results;
+
+    @JsonProperty
+    private final int total_results;
+
+    @JsonProperty
+    private final int total_pages;
+
+    @JsonProperty
+    private final int page;
+
+    public ResultsObject(List<T> results, int totalResults, int totalPages, int page) {
+        this.results = results;
+        this.total_results = totalResults;
+        this.total_pages = totalPages;
+        this.page = page;
+    }
+}

--- a/src/main/java/com/google/sps/servlets/book/BookSearchServlet.java
+++ b/src/main/java/com/google/sps/servlets/book/BookSearchServlet.java
@@ -8,6 +8,7 @@ import com.google.api.services.books.model.Volume;
 import com.google.api.services.books.model.Volumes;
 import com.google.gson.Gson;
 import com.google.sps.KeyConfig;
+import com.google.sps.model.results.ResultsObject;
 import org.json.simple.JSONObject;
 
 import javax.servlet.annotation.WebServlet;
@@ -70,26 +71,14 @@ public class BookSearchServlet extends HttpServlet {
 
         try {
             Volumes volumes = getResults(query, pageNumber);
-            response.getWriter().println(convertResultsToJson(volumes, pageNumber));
+            response.getWriter().println(gson.toJsonTree(
+                    new ResultsObject<>(volumes.getItems(),
+                            volumes.getTotalItems(),
+                            volumes.getTotalItems() / ((int) RESULTS_PER_PAGE),
+                            pageNumber)));
         }
         catch (Exception e) {
             response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
         }
-    }
-
-    /**
-     * convertResultsToJson converts a Volumes object to json to return to an API request
-     * @param searchResults volumes results from a given query
-     * @return json payload ready to send to user
-     */
-    private JSONObject convertResultsToJson(Volumes searchResults, int pageNumber) {
-        JSONObject json = new JSONObject();
-
-        json.put("results", gson.toJsonTree(searchResults.getItems()));
-        json.put("totalResults", searchResults.getTotalItems());
-        json.put("totalPages", searchResults.getTotalItems() / RESULTS_PER_PAGE);
-        json.put("page", pageNumber);
-
-        return json;
     }
 }

--- a/src/main/java/com/google/sps/servlets/book/BookSearchServlet.java
+++ b/src/main/java/com/google/sps/servlets/book/BookSearchServlet.java
@@ -86,10 +86,8 @@ public class BookSearchServlet extends HttpServlet {
         JSONObject json = new JSONObject();
 
         json.put("results", gson.toJsonTree(searchResults.getItems()));
-        // TODO: We should check if there is a parallel for this in Books, but I think it's superfluous to show in general
-        // json.put("totalResults", searchResults.getTotalResults());
-        // TODO: This doesn't work with the Books API b/c there are practically infinite pages. Maybe limit max pages.
-        // json.put("totalPages", searchResults.getTotalPages());
+        json.put("totalResults", searchResults.getTotalItems());
+        json.put("totalPages", searchResults.getTotalItems() / RESULTS_PER_PAGE);
         json.put("page", pageNumber);
 
         return json;

--- a/src/main/java/com/google/sps/servlets/recommendations/RecommendationsServlet.java
+++ b/src/main/java/com/google/sps/servlets/recommendations/RecommendationsServlet.java
@@ -1,0 +1,158 @@
+package com.google.sps.servlets.recommendations;
+
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.books.Books;
+import com.google.api.services.books.model.Volume;
+import com.google.api.services.books.model.Volumes;
+import com.google.gson.Gson;
+import com.google.sps.KeyConfig;
+import com.google.sps.util.Utils;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+
+import com.google.sps.util.Utils.ContentType;
+import info.movito.themoviedbapi.TmdbApi;
+import info.movito.themoviedbapi.TmdbMovies;
+import info.movito.themoviedbapi.model.core.MovieResultsPage;
+import org.json.simple.JSONObject;
+
+@WebServlet("/recommendations")
+public class RecommendationsServlet extends HttpServlet {
+
+    private static final long RESULTS_PER_PAGE = 20L;
+
+    private final TmdbMovies moviesApi = new TmdbMovies(new TmdbApi(KeyConfig.MOVIE_KEY));
+    private static final JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
+    private final Gson gson = new Gson();
+
+    /**
+     * doGet() returns recommendations relative to a given media item
+     * Expects ?mediaType={book | movie}&mediaId={id}
+     * Optionally accepts &pageNumber, defaulting to zero
+     * pageNumber is zero-indexed for both books and movies, automatically accounting for the 1-indexing of movies
+     * Returns error 400 if a parameter is empty or invalid (e.g. "bok")
+     * Returns error 400 if there is an error getting recommendations (such as when a book doesn't exist)
+     * @param request:  expects mediaType&mediaId, and optionally pageNumber
+     * @param response: returns a JSON object of either Volumes or Move
+     * @throws IOException
+     */
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        response.setContentType("application/json; charset=utf-8");
+
+        String mediaType = request.getParameter("mediaType");
+        String mediaId = request.getParameter("mediaId");
+        Integer pageNumber = Utils.parseInt(request.getParameter("pageNumber"));
+
+        Integer error = validateParameters(mediaType, mediaId, pageNumber);
+        if (error != null) {
+            response.sendError(error);
+            return;
+        }
+
+        if (pageNumber == null) pageNumber = 0;
+
+        sendRecommendations(mediaType, mediaId, pageNumber, response);
+    }
+
+    /**
+     * Validates the format and presence of the given parameters
+     * @return an error code on failure, null on success
+     */
+    private Integer validateParameters(String mediaType, String mediaId, Integer pageNumber) {
+        if (mediaId == null || mediaId.equals("")
+                || !ContentType.isType(mediaType)) {
+            return HttpServletResponse.SC_BAD_REQUEST;
+        }
+
+        // No error, i.e. good to go
+        return null;
+    }
+
+    private void sendRecommendations(String mediaType, String mediaId,
+                                     int pageNumber, HttpServletResponse response) throws IOException {
+        switch (mediaType) {
+            case ContentType.MOVIE: {
+                sendMovieRecommendations(mediaId, pageNumber, response);
+                break;
+            }
+            case ContentType.BOOK: {
+                sendBookRecommendations(mediaId, pageNumber, response);
+                break;
+            }
+        }
+    }
+
+    private void sendMovieRecommendations(String movieId, int pageNumber,
+                                          HttpServletResponse response) throws IOException {
+        Integer movieIdInt = Utils.parseInt(movieId);
+        if (movieIdInt == null) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+        }
+        try {
+            MovieResultsPage results = moviesApi.getRecommendedMovies(movieIdInt, null, pageNumber + 1);
+
+            JSONObject json = new JSONObject();
+            json.put("results", gson.toJsonTree(results.getResults()));
+            json.put("totalResults", results.getTotalResults());
+            json.put("totalPages", results.getTotalPages());
+            json.put("page", pageNumber);
+            response.getWriter().println(convertResultsToJson(results.getResults(),
+                    results.getTotalResults(), results.getTotalPages(), pageNumber));
+        } catch (Exception e) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+        }
+    }
+
+    private void sendBookRecommendations(String bookId, int pageNumber,
+                                         HttpServletResponse response) throws IOException {
+        try {
+            final NetHttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
+
+            Books books = new Books.Builder(httpTransport, jsonFactory, null)
+                    .setApplicationName(KeyConfig.APPLICATION_NAME)
+                    .build();
+
+            Volumes volumes = books.volumes()
+                    .associated()
+                    .list(bookId)
+                    .execute();
+
+            // Associated list is not paginated, so this extracts the right slice
+            List<Volume> volList = volumes.getItems();
+            int total = volList.size();
+            int startIndex = (int) RESULTS_PER_PAGE * pageNumber;
+            int endIndex = startIndex + (int) RESULTS_PER_PAGE;
+            if (endIndex >= volList.size()) endIndex = volList.size() - 1;
+            volList = volList.subList(startIndex, endIndex);
+
+            int totalPages = total / ((int) RESULTS_PER_PAGE);
+            if (totalPages == 0) totalPages = 1;
+
+            response.getWriter().println(convertResultsToJson(volList,
+                    total, totalPages, pageNumber));
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+        }
+    }
+
+    private <T> JSONObject convertResultsToJson(List<T> results, int totalResults, int totalPages, int page) {
+        JSONObject json = new JSONObject();
+        json.put("results", gson.toJsonTree(results));
+        json.put("totalResults", totalResults);
+        json.put("totalPages", totalPages);
+        json.put("page", page);
+
+        return json;
+    }
+}

--- a/src/test/java/com/google/sps/servlets/recommendations/RecommendationsServletTest.java
+++ b/src/test/java/com/google/sps/servlets/recommendations/RecommendationsServletTest.java
@@ -1,0 +1,113 @@
+package com.google.sps.servlets.recommendations;
+
+import com.google.sps.util.Utils.ContentType;
+import org.junit.Test;
+import org.mockito.Mockito;
+import static org.junit.Assert.*;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+public class RecommendationsServletTest extends Mockito {
+    public static final String GOOD_BOOK_ID = "ASImDQAAQBAJ";
+    public static final String GOOD_MOVIE_ID = "127";
+
+    @Test
+    public void testGetNullParameters() throws IOException {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        StringWriter stringWriter = new StringWriter();
+        PrintWriter writer = new PrintWriter(stringWriter);
+        when(response.getWriter()).thenReturn(writer);
+
+        new RecommendationsServlet().doGet(request, response);
+        writer.flush();
+
+        verify(response, times(1)).sendError(HttpServletResponse.SC_BAD_REQUEST);
+    }
+
+    @Test
+    public void testGetEmptyParameters() throws IOException {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getParameter("mediaType")).thenReturn("");
+        when(request.getParameter("mediaId")).thenReturn("");
+
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        StringWriter stringWriter = new StringWriter();
+        PrintWriter writer = new PrintWriter(stringWriter);
+        when(response.getWriter()).thenReturn(writer);
+
+        new RecommendationsServlet().doGet(request, response);
+        writer.flush();
+
+        verify(response, times(1)).sendError(HttpServletResponse.SC_BAD_REQUEST);
+    }
+
+    @Test
+    public void testGetGoodBook() throws IOException {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getParameter("mediaType")).thenReturn(ContentType.BOOK);
+        when(request.getParameter("mediaId")).thenReturn(GOOD_BOOK_ID);
+
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        StringWriter stringWriter = new StringWriter();
+        PrintWriter writer = new PrintWriter(stringWriter);
+        when(response.getWriter()).thenReturn(writer);
+
+        new RecommendationsServlet().doGet(request, response);
+        writer.flush();
+
+        assertFalse(writer.toString().trim().equals(""));
+    }
+
+    @Test
+    public void testGetGoodMovie() throws IOException {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getParameter("mediaType")).thenReturn(ContentType.MOVIE);
+        when(request.getParameter("mediaId")).thenReturn(GOOD_MOVIE_ID);
+
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        StringWriter stringWriter = new StringWriter();
+        PrintWriter writer = new PrintWriter(stringWriter);
+        when(response.getWriter()).thenReturn(writer);
+
+        new RecommendationsServlet().doGet(request, response);
+        writer.flush();
+
+        assertFalse(writer.toString().trim().equals(""));
+    }
+
+    @Test
+    public void testGetSecondPage() throws IOException {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getParameter("mediaType")).thenReturn(ContentType.MOVIE);
+        when(request.getParameter("mediaId")).thenReturn(GOOD_MOVIE_ID);
+
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        StringWriter stringWriter = new StringWriter();
+        PrintWriter writer = new PrintWriter(stringWriter);
+        when(response.getWriter()).thenReturn(writer);
+
+        new RecommendationsServlet().doGet(request, response);
+        writer.flush();
+        String firstPage = writer.toString();
+
+        stringWriter = new StringWriter();
+        writer = new PrintWriter(stringWriter);
+        when(response.getWriter()).thenReturn(writer);
+        when(request.getParameter("pageNumber")).thenReturn("1");
+        new RecommendationsServlet().doGet(request, response);
+        writer.flush();
+        String secondPage = writer.toString();
+
+        assertFalse(firstPage.trim().equals(secondPage.trim()));
+    }
+}


### PR DESCRIPTION
## BookSearchServlet
- Now returns total items and total pages in the same format as MovieSearchServlet

## RecommendationsServlet
- Takes required parameters `?mediaType={book | movie}&mediaId={id}`
- Takes an optional parameter `&pageNumber`, zero-indexed, defaulting to zero
- For `mediaType == movie`, uses TMDB API recommendation feature
- **For `mediaType == book`, uses the `associated` feature of the Google Books API**
    - This was hardly documented, but it is luckily exactly what we want
    - Works very similarly to TMDB recommendations
    - **Caveat: ** seemingly only returns 9 results
- Returns an object identical to that returned by `MovieSearchServlet` and `BookSearchServlet`
    - `{ results: [MovieDb or Volume], total_results: int total_pages: int, page: int}`

## RecommendationsServletTest
- Tests appropriate error given empty/null parameters
- Tests non-empty output from valid queries
- Tests non-equal output for pages 0 and 1 of a valid movie query

## Frontend
- Shows total number of results for books as it was previously only shown for movies