### PR TITLE
Force book images to HTTPS and normalize search and details

### DIFF
--- a/mediaphile/src/app/info.service.ts
+++ b/mediaphile/src/app/info.service.ts
@@ -186,4 +186,11 @@ export class InfoService {
       }
     })
   }
+
+  public toHttps(href: string) {
+    if (href.startsWith("http://")) {
+      return "https://" + href.substr(7);
+    }
+    return href;
+  }
 }

--- a/mediaphile/src/app/pages/book-details/book-details.component.scss
+++ b/mediaphile/src/app/pages/book-details/book-details.component.scss
@@ -93,6 +93,10 @@
   height:100vh;
 }
 
+.reviews {
+  margin-top:1em;
+}
+
 @media only screen and (max-width: 768px) {
   img {
     width: 80% !important;

--- a/mediaphile/src/app/pages/book-details/book-details.component.ts
+++ b/mediaphile/src/app/pages/book-details/book-details.component.ts
@@ -79,7 +79,7 @@ export class BookDetailsComponent implements OnInit {
 
   public getEntityPosterUrl(): string {
     if(this.bookData && "imageLinks" in this.bookData["volumeInfo"]) {
-      return this.bookData["volumeInfo"]["imageLinks"]["thumbnail"]
+      return this.infoSvc.toHttps(this.bookData["volumeInfo"]["imageLinks"]["thumbnail"]);
     }
     return "assets/poster-placeholder.png"
   }

--- a/mediaphile/src/app/pages/search/entity/entity.component.scss
+++ b/mediaphile/src/app/pages/search/entity/entity.component.scss
@@ -1,5 +1,6 @@
 img {
   height: 82%;
+  min-width: 54.6%;
   box-shadow: 2px 2px 2px #bdbdbd;
   margin-right:1em;
   transition: 0.3s;

--- a/mediaphile/src/app/pages/search/entity/entity.component.spec.ts
+++ b/mediaphile/src/app/pages/search/entity/entity.component.spec.ts
@@ -1,6 +1,10 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { EntityComponent } from './entity.component';
+import {HttpClientTestingModule} from "@angular/common/http/testing";
+import {RouterTestingModule} from "@angular/router/testing";
+import {InfoService} from "../../../info.service";
+import {LoginStatus} from "../../../auth/login.status";
 
 describe('EntityComponent', () => {
   let component: EntityComponent;
@@ -8,7 +12,9 @@ describe('EntityComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ EntityComponent ]
+      declarations: [ EntityComponent ],
+      imports: [ HttpClientTestingModule, RouterTestingModule.withRoutes([])],
+      providers: [ InfoService, LoginStatus ]
     })
     .compileComponents();
   }));

--- a/mediaphile/src/app/pages/search/entity/entity.component.ts
+++ b/mediaphile/src/app/pages/search/entity/entity.component.ts
@@ -1,4 +1,5 @@
 import {Component, Input, OnInit} from '@angular/core';
+import {InfoService} from "../../../info.service";
 
 @Component({
   selector: 'app-entity',
@@ -13,7 +14,7 @@ export class EntityComponent implements OnInit {
   @Input()
   type: string
 
-  constructor() { }
+  constructor(private infoSvc: InfoService) { }
 
   ngOnInit(): void {
 
@@ -22,7 +23,7 @@ export class EntityComponent implements OnInit {
   public getEntityImageUrl() : string {
     if(this.type === "book") {
       if("imageLinks" in this.entity["volumeInfo"]) {
-        return this.entity["volumeInfo"]["imageLinks"]["thumbnail"]
+        return this.infoSvc.toHttps(this.entity["volumeInfo"]["imageLinks"]["thumbnail"]);
       }
     } else if(this.type === "movie") {
       if(this.entity["poster_path"]) {


### PR DESCRIPTION
Various bug fixes and polishes for the frontend

- Books search results and details pages will now use `https://` to get book images
    - As long as this was our only instance of mixed protocols, this should allow the deployed version to use `https://`
- Added margin above reviews on books details page, matching the movies details page
- Entities in the search results will now display as full-sized white rectangles before the images load
    - Before, they would display as lines as there was no content to decide their width