### PR TITLE
Improve reviews journey by hiding button and reordering reviews

### DIFF
--- a/mediaphile/src/app/info.service.ts
+++ b/mediaphile/src/app/info.service.ts
@@ -121,6 +121,24 @@ export class InfoService {
     });
   }
 
+  public getReviewsByUser(id: string) {
+    return this.http.get<Review[]>(this.getReviews, {
+      params: {
+        userId: id
+      }
+    });
+  }
+
+  public getSpecificReview(contentId: string, contentType: string, userId: string) {
+    return this.http.get<Review>(this.getReviews, {
+      params: {
+        contentType: contentType,
+        contentId: contentId,
+        userId: userId
+      }
+    });
+  }
+
   public postReviewForMedia(authorId: string, authorName: string,
                             contentType: string, contentId: string, contentTitle: string,
                             artUrl: string,

--- a/mediaphile/src/app/pages/book-details/book-details.component.html
+++ b/mediaphile/src/app/pages/book-details/book-details.component.html
@@ -27,7 +27,7 @@
                 <button (click)="addToWatchedList()" *ngIf="!hasWatched" class="btn-watch">Mark as Read</button>
                 <button (click)="removeFromList('viewed')" *ngIf="hasWatched" class="btn-watch red-button"><fa-icon [icon]="miniusCircle"></fa-icon> Remove from Read</button>
 
-                <button (click)="scroll(reviews)" class="btn-wait">Write a Review</button>
+                <button (click)="scroll(reviews)" class="btn-wait">Go to Reviews</button>
               </div>
             </div>
             <ng-template #listloading>

--- a/mediaphile/src/app/pages/helper/review/review.component.html
+++ b/mediaphile/src/app/pages/helper/review/review.component.html
@@ -1,5 +1,9 @@
 <div class = "review-container" *ngIf="reviews | async as reviews ; else loading">
-  <button  *ngIf = "(loginStatus.sharedStatus | async) && !userHasReview; else login" class="btn btn-primary review" data-toggle="modal" data-target="#exampleModal">Write a Review</button>
+  <div *ngIf="!userHasReview">
+    <button *ngIf = "(loginStatus.sharedStatus | async); else login"
+            class="btn btn-primary review" data-toggle="modal" data-target="#exampleModal">
+      Write a Review</button>
+  </div>
   <ng-template #login>
     <button class="btn btn-primary review" (click)="loginWithRedirect()">Write a Review</button>
   </ng-template>

--- a/mediaphile/src/app/pages/helper/review/review.component.html
+++ b/mediaphile/src/app/pages/helper/review/review.component.html
@@ -1,10 +1,11 @@
 <div class = "review-container" *ngIf="reviews | async as reviews ; else loading">
-  <button  *ngIf = "(loginStatus.sharedStatus | async); else login" class="btn btn-primary review" data-toggle="modal" data-target="#exampleModal">Write a Review</button>
+  <button  *ngIf = "(loginStatus.sharedStatus | async) && !userHasReview; else login" class="btn btn-primary review" data-toggle="modal" data-target="#exampleModal">Write a Review</button>
   <ng-template #login>
     <button class="btn btn-primary review" (click)="loginWithRedirect()">Write a Review</button>
   </ng-template>
+  <app-review-entity *ngIf="userHasReview" [review]="selfReview"></app-review-entity>
   <div *ngFor="let review of reviews">
-    <app-review-entity [review]="review"></app-review-entity>
+    <app-review-entity *ngIf="!matchesSelfReview(review['id'])" [review]="review"></app-review-entity>
   </div>
   <div *ngIf="reviews.length == 0">
     <h3><fa-icon [icon]="faEye"></fa-icon> No reviews yet! Be the first to add one</h3>

--- a/mediaphile/src/app/pages/helper/review/review.component.ts
+++ b/mediaphile/src/app/pages/helper/review/review.component.ts
@@ -28,15 +28,30 @@ export class ReviewComponent implements OnInit {
   faEye = faEye;
 
   reviews: Observable<Review[]>
+  selfReview: Review;
+  userHasReview: boolean = false;
 
   constructor(private infoSvc: InfoService, private router: Router, public loginStatus: LoginStatus) { }
 
   ngOnInit(): void {
     this.reviews = this.infoSvc.getReviewsForMedia(this.id, this.type);
+    this.loginStatus.sharedAccountId.subscribe(userId => {
+      this.infoSvc.getSpecificReview(this.id, this.type, userId).subscribe(review => {
+        if (review != undefined) {
+          this.selfReview = review;
+          this.userHasReview = true;
+        }
+      });
+    });
+
   }
 
   loginWithRedirect() {
     this.router.navigate(["/login"], {queryParams: {redirect: this.router.url}});
+  }
+
+  matchesSelfReview(reviewId: number): boolean {
+    return (this.selfReview != undefined) && (reviewId == this.selfReview.id);
   }
 
 }

--- a/src/main/java/com/google/sps/servlets/review/ReviewServlet.java
+++ b/src/main/java/com/google/sps/servlets/review/ReviewServlet.java
@@ -225,7 +225,7 @@ public class ReviewServlet extends HttpServlet {
         }
         else {
             List<ReviewObject> reviews = ofy().load().type(ReviewObject.class)
-                    .filter("authorId", userId)
+                    .filter("userId", userId)
                     .filter("contentType", contentType)
                     .filter("contentId", contentId)
                     .list();


### PR DESCRIPTION
- The "write a review" button will no longer display after the user has made a review
- The user's own review will always display at the top of the list
    - A check is made to ensure it is not duplicated below, i.e. their own review is simply moved to the top
- Changed the link to reviews from "write a review" to "go to reviews"
    - This makes more sense on small screens, and accounts for the case when a user has already made a review
- Fixed a bug in the `sendSpecificReview` function, so it can now return a user's own review