### PR TITLE
Force correct recommendations request origin and fix plural in tabs

### DIFF
--- a/mediaphile/src/app/pages/search/search.component.html
+++ b/mediaphile/src/app/pages/search/search.component.html
@@ -3,10 +3,10 @@
     <nav>
       <div class="nav nav-tabs" id="nav-tab" role="tablist">
         <a class="nav-item nav-link active" id="nav-home-tab" data-toggle="tab" href="#nav-home" role="tab" aria-controls="nav-home" aria-selected="true">
-          <fa-icon [icon]="faFilm"></fa-icon> <span class = "text-header"> Movie</span>
+          <fa-icon [icon]="faFilm"></fa-icon> <span class = "text-header"> Movies</span>
         </a>
         <a class="nav-item nav-link" id="nav-profile-tab" data-toggle="tab" href="#nav-profile" role="tab" aria-controls="nav-profile" aria-selected="false">
-          <fa-icon [icon]="faBook"></fa-icon> <span class = "text-header"> Book</span>
+          <fa-icon [icon]="faBook"></fa-icon> <span class = "text-header"> Books</span>
         </a>
         <a class="nav-item nav-link" id="nav-users-tab" data-toggle="tab" href="#nav-users" role="tab" aria-controls="nav-users" aria-selected="false">
           <fa-icon [icon]="faUsers"></fa-icon> <span class = "text-header"> Users</span>

--- a/src/main/java/com/google/sps/servlets/recommendations/RecommendationsServlet.java
+++ b/src/main/java/com/google/sps/servlets/recommendations/RecommendationsServlet.java
@@ -124,6 +124,7 @@ public class RecommendationsServlet extends HttpServlet {
             Volumes volumes = books.volumes()
                     .associated()
                     .list(bookId)
+                    .set("country", "US")
                     .execute();
 
             // Associated list is not paginated, so this extracts the right slice


### PR DESCRIPTION
- Fix a bug that prevented book recommendations on the deployed service
    - Properly marks the origin of the API request, just like we've done with books search and details
- Make all search tabs plural, i.e. "Book" -> "Books"