### PR TITLE
Recommendations workarounds

### DIFF
--- a/src/main/java/com/google/sps/servlets/recommendations/RecommendationsServlet.java
+++ b/src/main/java/com/google/sps/servlets/recommendations/RecommendationsServlet.java
@@ -181,12 +181,9 @@ public class RecommendationsServlet extends HttpServlet {
         List<String> categories = volume.getVolumeInfo().getCategories();
         String query;
         if (categories != null && categories.size() > 0) {
-            String category = categories.get(0).replaceAll("\\s", "_");
-            query = "subject:" + category;
+            query = "subject:" + spacesToUnderscores(categories.get(0));
         } else {
-            String[] words = volume.getVolumeInfo().getTitle().split("[\\s-.,!?]+");
-            words = Arrays.copyOfRange(words, 0, Math.min(words.length, 3));
-            query = String.join(" ", words);
+            query = getFirstWords(volume.getVolumeInfo().getTitle(), 3);
         }
 
         Volumes volumes = books.volumes().list(query)
@@ -210,5 +207,15 @@ public class RecommendationsServlet extends HttpServlet {
         } catch (Exception e) {
             response.sendError(HttpServletResponse.SC_BAD_REQUEST);
         }
+    }
+
+    String spacesToUnderscores(String str) {
+        return str.replaceAll("\\s", "_");
+    }
+
+    String getFirstWords(String str, int n) {
+        String[] words = str.split("[\\s-.,!?]+");
+        words = Arrays.copyOfRange(words, 0, Math.min(words.length, n));
+        return String.join(" ", words);
     }
 }

--- a/src/main/java/com/google/sps/servlets/recommendations/RecommendationsServlet.java
+++ b/src/main/java/com/google/sps/servlets/recommendations/RecommendationsServlet.java
@@ -19,7 +19,6 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.rmi.server.ExportException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;


### PR DESCRIPTION
- The system will first attempt to use the original "associated" method for book recommendations
- That method fails quickly when it fails, and the failure will now be caught as an exception, calling the `bookRecommendationsFallback()` function
    - This function takes ownership of the Books API accessor object, speeding up the fallback mechanism
- The fallback will try the following, in order
    - If the book has category labels, match based on the first category by forming a `subject:` query
    - Else, take the first few words of the title (at most 3), and search by those